### PR TITLE
Feat: max gas issuance type change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1146,15 +1146,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "approx"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "arbitrary"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2553,52 +2544,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cust"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6cc71911e179f12483b9734120b45bd00bf64fab085cc4818428523eedd469"
-dependencies = [
- "bitflags 1.3.2",
- "bytemuck",
- "cust_core",
- "cust_derive",
- "cust_raw",
- "find_cuda_helper",
-]
-
-[[package]]
-name = "cust_core"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "039f79662cb8f890cbf335e818cd522d6e3a53fe63f61d1aaaf859cd3d975f06"
-dependencies = [
- "cust_derive",
- "glam",
- "mint",
- "vek",
-]
-
-[[package]]
-name = "cust_derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a3bc95fe629aed92b2423de6ccff9e40174b21d19cb6ee6281a4d04ac72f66"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "cust_raw"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf40d6ade12cb9828bbc844b9875c7b93d25e67a3c9bf61c7aa3ae09e402bf8"
-dependencies = [
- "find_cuda_helper",
-]
-
-[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3530,15 +3475,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "find_cuda_helper"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f9e65c593dd01ac77daad909ea4ad17f0d6d1776193fc8ea766356177abdad"
-dependencies = [
- "glob",
-]
-
-[[package]]
 name = "fixed-hash"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3829,15 +3765,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
-name = "glam"
-version = "0.20.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43e957e744be03f5801a55472f593d43fabdebf25a4585db250f04d86b1675f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4114,15 +4041,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "home"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
-dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4332,7 +4250,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "system-configuration 0.6.1",
  "tokio",
  "tower-service",
@@ -5200,12 +5118,6 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]
-
-[[package]]
-name = "mint"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e53debba6bda7a793e5f99b8dacf19e626084f525f7829104ba9898f367d85ff"
 
 [[package]]
 name = "mio"
@@ -7236,7 +7148,7 @@ dependencies = [
 [[package]]
 name = "reth-blockchain-tree-api"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -7252,7 +7164,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -7278,7 +7190,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-chains 0.2.6",
  "alloy-consensus 0.7.3",
@@ -7298,7 +7210,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -7315,7 +7227,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
@@ -7326,7 +7238,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -7340,7 +7252,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -7355,7 +7267,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-primitives 0.8.25",
@@ -7387,7 +7299,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-genesis",
@@ -7412,7 +7324,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-eips 0.7.3",
  "alloy-primitives 0.8.25",
@@ -7426,7 +7338,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-primitives 0.8.25",
@@ -7448,7 +7360,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "reth-blockchain-tree-api",
  "reth-consensus",
@@ -7461,7 +7373,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-chains 0.2.6",
  "alloy-consensus 0.7.3",
@@ -7481,7 +7393,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -7497,7 +7409,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-chains 0.2.6",
  "alloy-primitives 0.8.25",
@@ -7514,7 +7426,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -7540,7 +7452,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -7560,7 +7472,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-eips 0.7.3",
  "alloy-primitives 0.8.25",
@@ -7576,7 +7488,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -7593,7 +7505,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "serde",
  "serde_json",
@@ -7603,7 +7515,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "bitflags 2.9.1",
  "byteorder",
@@ -7620,7 +7532,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "bindgen",
  "cc",
@@ -7629,7 +7541,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "metrics",
  "metrics-derive",
@@ -7638,7 +7550,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-primitives 0.8.25",
 ]
@@ -7646,7 +7558,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -7668,7 +7580,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-primitives 0.8.25",
  "alloy-rlp",
@@ -7681,7 +7593,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "reth-ethereum-forks",
  "reth-net-banlist",
@@ -7693,7 +7605,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "anyhow",
  "bincode",
@@ -7709,7 +7621,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -7721,7 +7633,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-rpc-types-engine",
  "async-trait",
@@ -7735,7 +7647,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-eips 0.7.3",
  "alloy-primitives 0.8.25",
@@ -7754,7 +7666,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -7788,7 +7700,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -7810,7 +7722,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -7855,7 +7767,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-primitives 0.8.25",
  "bytes",
@@ -7869,7 +7781,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-eips 0.7.3",
  "alloy-primitives 0.8.25",
@@ -7885,7 +7797,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-primitives 0.8.25",
  "bytes",
@@ -7898,7 +7810,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-primitives 0.8.25",
  "derive_more 1.0.0",
@@ -7909,7 +7821,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -7935,7 +7847,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-eips 0.7.3",
  "alloy-primitives 0.8.25",
@@ -7949,7 +7861,7 @@ dependencies = [
 [[package]]
 name = "reth-taiko-chainspec"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-chains 0.2.6",
  "alloy-consensus 0.7.3",
@@ -7968,7 +7880,7 @@ dependencies = [
 [[package]]
 name = "reth-taiko-consensus"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-primitives 0.8.25",
@@ -7986,7 +7898,7 @@ dependencies = [
 [[package]]
 name = "reth-taiko-engine-types"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-eips 0.7.3",
  "alloy-primitives 0.8.25",
@@ -8002,7 +7914,7 @@ dependencies = [
 [[package]]
 name = "reth-taiko-evm"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -8028,7 +7940,7 @@ dependencies = [
 [[package]]
 name = "reth-taiko-forks"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-chains 0.2.6",
  "alloy-primitives 0.8.25",
@@ -8038,7 +7950,7 @@ dependencies = [
 [[package]]
 name = "reth-taiko-primitives"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-primitives 0.8.25",
  "alloy-rlp",
@@ -8053,7 +7965,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "clap 4.5.42",
  "eyre",
@@ -8068,7 +7980,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-eips 0.7.3",
@@ -8093,7 +8005,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus 0.7.3",
  "alloy-genesis",
@@ -8114,7 +8026,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-primitives 0.8.25",
  "alloy-rlp",
@@ -8134,7 +8046,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-primitives 0.8.25",
  "alloy-rlp",
@@ -8149,7 +8061,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "zstd",
 ]
@@ -8362,13 +8274,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a25d00769a0f855d4973e8a85dbffe6e13889ca6a4703cf98d0a2976bdc2be17"
 dependencies = [
  "cc",
- "cust",
  "derive_more 2.0.1",
  "glob",
  "risc0-build-kernel",
  "risc0-core",
  "risc0-sys",
- "sppark",
 ]
 
 [[package]]
@@ -8380,7 +8290,6 @@ dependencies = [
  "anyhow",
  "bytemuck",
  "cfg-if",
- "cust",
  "downloader",
  "hex",
  "lazy-regex",
@@ -8407,7 +8316,6 @@ dependencies = [
  "risc0-build-kernel",
  "risc0-core",
  "risc0-sys",
- "sppark",
 ]
 
 [[package]]
@@ -8449,13 +8357,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddac6b8acb1db761872fafa063155d99fe2cc845dc60037cde9ac05466044898"
 dependencies = [
  "cc",
- "cust",
  "derive_more 2.0.1",
  "glob",
  "risc0-build-kernel",
  "risc0-core",
  "risc0-sys",
- "sppark",
 ]
 
 [[package]]
@@ -8534,9 +8440,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11abd6064c039f24b58676419cd13c92cbf4858e66948dd55b188b03511db44c"
 dependencies = [
  "anyhow",
- "cust",
  "risc0-build-kernel",
- "sppark",
 ]
 
 [[package]]
@@ -8560,7 +8464,6 @@ dependencies = [
  "borsh",
  "bytemuck",
  "cfg-if",
- "cust",
  "digest 0.10.7",
  "ff 0.13.1",
  "hex",
@@ -10201,16 +10104,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sppark"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdc4f02f557e3037bbe2a379cac8be6e014a67beb7bf0996b536979392f6361"
-dependencies = [
- "cc",
- "which",
-]
-
-[[package]]
 name = "stability"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11483,18 +11376,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "vek"
-version = "0.15.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8085882662f9bc47fc8b0cdafa5e19df8f592f650c02b9083da8d45ac9eebd17"
-dependencies = [
- "approx",
- "num-integer",
- "num-traits",
- "rustc_version 0.4.1",
-]
-
-[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11674,18 +11555,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,11 +47,11 @@ raiko-reqactor = { path = "./reqactor" }
 raiko-ballot = { path = "./ballot" }
 
 # reth
-reth-chainspec = { git = "https://github.com/NethermindEth/surge-reth.git", tag = "v1.1.4-surge", default-features = false }
-reth-taiko-evm = { git = "https://github.com/NethermindEth/surge-reth.git", tag = "v1.1.4-surge", default-features = false, features = [
+reth-chainspec = { git = "https://github.com/NethermindEth/surge-reth.git", branch = "surge", default-features = false }
+reth-taiko-evm = { git = "https://github.com/NethermindEth/surge-reth.git", branch = "surge", default-features = false, features = [
     "std",
 ] }
-reth-primitives = { git = "https://github.com/NethermindEth/surge-reth.git", tag = "v1.1.4-surge", default-features = false, features = [
+reth-primitives = { git = "https://github.com/NethermindEth/surge-reth.git", branch = "surge", default-features = false, features = [
     "alloy-compat",
     "c-kzg",
     "serde-bincode-compat",
@@ -60,16 +60,16 @@ reth-primitives = { git = "https://github.com/NethermindEth/surge-reth.git", tag
 ] }
 
 
-reth-evm-ethereum = { git = "https://github.com/NethermindEth/surge-reth.git", tag = "v1.1.4-surge", default-features = false }
-reth-consensus = { git = "https://github.com/NethermindEth/surge-reth.git", tag = "v1.1.4-surge", default-features = false }
-reth-ethereum-consensus = { git = "https://github.com/NethermindEth/surge-reth.git", tag = "v1.1.4-surge", default-features = false }
-reth-evm = { git = "https://github.com/NethermindEth/surge-reth.git", tag = "v1.1.4-surge", default-features = false }
-reth-rpc-types-compat = { git = "https://github.com/NethermindEth/surge-reth.git", tag = "v1.1.4-surge", default-features = false }
-reth-revm = { git = "https://github.com/NethermindEth/surge-reth.git", tag = "v1.1.4-surge", default-features = false }
-reth-provider = { git = "https://github.com/NethermindEth/surge-reth.git", tag = "v1.1.4-surge", default-features = false }
-reth-taiko-consensus = { git = "https://github.com/NethermindEth/surge-reth.git", tag = "v1.1.4-surge", default-features = false }
-reth-taiko-forks = { git = "https://github.com/NethermindEth/surge-reth.git", tag = "v1.1.4-surge", default-features = false }
-reth-taiko-chainspec = { git = "https://github.com/NethermindEth/surge-reth.git", tag = "v1.1.4-surge", default-features = false }
+reth-evm-ethereum = { git = "https://github.com/NethermindEth/surge-reth.git", branch = "surge", default-features = false }
+reth-consensus = { git = "https://github.com/NethermindEth/surge-reth.git", branch = "surge", default-features = false }
+reth-ethereum-consensus = { git = "https://github.com/NethermindEth/surge-reth.git", branch = "surge", default-features = false }
+reth-evm = { git = "https://github.com/NethermindEth/surge-reth.git", branch = "surge", default-features = false }
+reth-rpc-types-compat = { git = "https://github.com/NethermindEth/surge-reth.git", branch = "surge", default-features = false }
+reth-revm = { git = "https://github.com/NethermindEth/surge-reth.git", branch = "surge", default-features = false }
+reth-provider = { git = "https://github.com/NethermindEth/surge-reth.git", branch = "surge", default-features = false }
+reth-taiko-consensus = { git = "https://github.com/NethermindEth/surge-reth.git", branch = "surge", default-features = false }
+reth-taiko-forks = { git = "https://github.com/NethermindEth/surge-reth.git", branch = "surge", default-features = false }
+reth-taiko-chainspec = { git = "https://github.com/NethermindEth/surge-reth.git", branch = "surge", default-features = false }
 
 
 reqwest_alloy = { package = "reqwest", version = "0.12.4", features = ["json"] }

--- a/lib/src/input/ontake.rs
+++ b/lib/src/input/ontake.rs
@@ -9,7 +9,7 @@ sol! {
         uint8 sharingPctg;
         uint32 gasIssuancePerSecond;
         uint64 minGasExcess;
-        uint64 maxGasIssuancePerBlock;
+        uint32 maxGasIssuancePerBlock;
     }
 
     #[derive(Debug, Default, Deserialize, Serialize)]

--- a/lib/src/input/pacaya.rs
+++ b/lib/src/input/pacaya.rs
@@ -9,7 +9,7 @@ sol! {
         uint8 sharingPctg;
         uint32 gasIssuancePerSecond;
         uint64 minGasExcess;
-        uint64 maxGasIssuancePerBlock;
+        uint32 maxGasIssuancePerBlock;
     }
 
     #[derive(Debug, Default, Deserialize, Serialize)]

--- a/provers/risc0/driver/Cargo.toml
+++ b/provers/risc0/driver/Cargo.toml
@@ -65,6 +65,7 @@ enable = [
     "reqwest",
     "lazy_static",
 ]
-cuda = ["risc0-zkvm?/cuda"]
+# cuda = []
+cuda = []
 metal = ["risc0-zkvm?/metal"]
 bench = []

--- a/provers/risc0/driver/Cargo.toml
+++ b/provers/risc0/driver/Cargo.toml
@@ -65,7 +65,6 @@ enable = [
     "reqwest",
     "lazy_static",
 ]
-# cuda = []
-cuda = []
+cuda = ["risc0-zkvm?/cuda"]
 metal = ["risc0-zkvm?/metal"]
 bench = []

--- a/provers/risc0/guest/Cargo.lock
+++ b/provers/risc0/guest/Cargo.lock
@@ -168,7 +168,7 @@ dependencies = [
  "derive_more 1.0.0",
  "once_cell",
  "serde",
- "sha2 0.10.6",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -637,7 +637,7 @@ dependencies = [
  "digest 0.10.7",
  "fnv",
  "merlin",
- "sha2 0.10.6",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2415,7 +2415,7 @@ dependencies = [
  "elliptic-curve",
  "once_cell",
  "risc0-bigint2",
- "sha2 0.10.6",
+ "sha2 0.10.9",
  "signature",
 ]
 
@@ -2446,7 +2446,7 @@ dependencies = [
  "bincode",
  "blst",
  "serde",
- "sha2 0.10.6",
+ "sha2 0.10.9",
  "siphasher",
 ]
 
@@ -3365,7 +3365,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 [[package]]
 name = "reth-chainspec"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-chains 0.2.6",
  "alloy-consensus",
@@ -3385,7 +3385,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 0.7.3",
@@ -3402,7 +3402,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
@@ -3413,7 +3413,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 0.7.3",
@@ -3427,7 +3427,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 0.7.3",
@@ -3442,7 +3442,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives 0.8.25",
@@ -3467,7 +3467,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -3492,7 +3492,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-eips 0.7.3",
  "alloy-primitives 0.8.25",
@@ -3506,7 +3506,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 0.7.3",
@@ -3522,7 +3522,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-chains 0.2.6",
  "alloy-primitives 0.8.25",
@@ -3539,7 +3539,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 0.7.3",
@@ -3565,7 +3565,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 0.7.3",
@@ -3585,7 +3585,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-eips 0.7.3",
  "alloy-primitives 0.8.25",
@@ -3601,7 +3601,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 0.7.3",
@@ -3618,7 +3618,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "serde",
  "serde_json",
@@ -3628,7 +3628,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "metrics",
  "metrics-derive",
@@ -3637,7 +3637,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-primitives 0.8.25",
  "alloy-rlp",
@@ -3650,7 +3650,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3666,7 +3666,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 0.7.3",
@@ -3700,7 +3700,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 0.7.3",
@@ -3722,7 +3722,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-primitives 0.8.25",
  "bytes",
@@ -3736,7 +3736,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-eips 0.7.3",
  "alloy-primitives 0.8.25",
@@ -3752,7 +3752,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-primitives 0.8.25",
  "bytes",
@@ -3765,7 +3765,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-primitives 0.8.25",
  "derive_more 1.0.0",
@@ -3776,7 +3776,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 0.7.3",
@@ -3802,7 +3802,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-eips 0.7.3",
  "alloy-primitives 0.8.25",
@@ -3816,7 +3816,7 @@ dependencies = [
 [[package]]
 name = "reth-taiko-chainspec"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-chains 0.2.6",
  "alloy-consensus",
@@ -3835,7 +3835,7 @@ dependencies = [
 [[package]]
 name = "reth-taiko-consensus"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives 0.8.25",
@@ -3853,7 +3853,7 @@ dependencies = [
 [[package]]
 name = "reth-taiko-evm"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 0.7.3",
@@ -3879,7 +3879,7 @@ dependencies = [
 [[package]]
 name = "reth-taiko-forks"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-chains 0.2.6",
  "alloy-primitives 0.8.25",
@@ -3889,7 +3889,7 @@ dependencies = [
 [[package]]
 name = "reth-taiko-primitives"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-primitives 0.8.25",
  "alloy-rlp",
@@ -3904,7 +3904,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "clap",
  "eyre",
@@ -3919,7 +3919,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 0.7.3",
@@ -3942,7 +3942,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -3963,7 +3963,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-primitives 0.8.25",
  "alloy-rlp",
@@ -3981,7 +3981,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-primitives 0.8.25",
  "alloy-rlp",
@@ -3996,7 +3996,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "zstd",
 ]
@@ -4037,7 +4037,7 @@ dependencies = [
  "revm-primitives",
  "ripemd",
  "secp256k1",
- "sha2 0.10.6",
+ "sha2 0.10.9",
  "substrate-bn",
 ]
 
@@ -4235,7 +4235,7 @@ dependencies = [
  "risc0-core",
  "risc0-zkvm-platform",
  "serde",
- "sha2 0.10.6",
+ "sha2 0.10.9",
  "stability",
  "tracing",
 ]
@@ -4264,7 +4264,7 @@ dependencies = [
  "rrs-lib",
  "semver 1.0.26",
  "serde",
- "sha2 0.10.6",
+ "sha2 0.10.9",
  "stability",
  "tracing",
 ]

--- a/provers/sp1/guest/Cargo.lock
+++ b/provers/sp1/guest/Cargo.lock
@@ -543,9 +543,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.19"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -573,22 +573,22 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.9"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -923,9 +923,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "441473f2b4b0459a68628c744bc61d23e730fb00128b841d30fa4bb3972257e4"
+checksum = "4f154e572231cb6ba2bd1176980827e3d5dc04cc183a75dea38109fbdd672d29"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1026,9 +1026,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.42"
+version = "4.5.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed87a9d530bb41a67537289bafcac159cb3ee28460e0a4571123d2a778a6a882"
+checksum = "50fd97c9dc2399518aa331917ac6f274280ec5eb34e555dd291899745c48ec6f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1036,9 +1036,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.42"
+version = "4.5.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f4f3f3c77c94aff3c7e9aac9a2ca1974a5adf392a8bb751e827d6d127ab966"
+checksum = "c35b5830294e1fa0462034af85cc95225a4cb07092c088c55bda3147cfcd8f65"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2055,9 +2055,9 @@ dependencies = [
 
 [[package]]
 name = "indenter"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indexmap"
@@ -3306,7 +3306,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 [[package]]
 name = "reth-chainspec"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-chains 0.2.6",
  "alloy-consensus",
@@ -3326,7 +3326,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 0.7.3",
@@ -3343,7 +3343,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
@@ -3354,7 +3354,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 0.7.3",
@@ -3368,7 +3368,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 0.7.3",
@@ -3383,7 +3383,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives 0.8.25",
@@ -3408,7 +3408,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -3433,7 +3433,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-eips 0.7.3",
  "alloy-primitives 0.8.25",
@@ -3447,7 +3447,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 0.7.3",
@@ -3463,7 +3463,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-chains 0.2.6",
  "alloy-primitives 0.8.25",
@@ -3480,7 +3480,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 0.7.3",
@@ -3506,7 +3506,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 0.7.3",
@@ -3526,7 +3526,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-eips 0.7.3",
  "alloy-primitives 0.8.25",
@@ -3542,7 +3542,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 0.7.3",
@@ -3559,7 +3559,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "serde",
  "serde_json",
@@ -3569,7 +3569,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "metrics",
  "metrics-derive",
@@ -3578,7 +3578,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-primitives 0.8.25",
  "alloy-rlp",
@@ -3591,7 +3591,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3607,7 +3607,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 0.7.3",
@@ -3641,7 +3641,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 0.7.3",
@@ -3663,7 +3663,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-primitives 0.8.25",
  "bytes",
@@ -3677,7 +3677,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-eips 0.7.3",
  "alloy-primitives 0.8.25",
@@ -3693,7 +3693,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-primitives 0.8.25",
  "bytes",
@@ -3706,7 +3706,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-primitives 0.8.25",
  "derive_more 1.0.0",
@@ -3717,7 +3717,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 0.7.3",
@@ -3743,7 +3743,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-eips 0.7.3",
  "alloy-primitives 0.8.25",
@@ -3757,7 +3757,7 @@ dependencies = [
 [[package]]
 name = "reth-taiko-chainspec"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-chains 0.2.6",
  "alloy-consensus",
@@ -3776,7 +3776,7 @@ dependencies = [
 [[package]]
 name = "reth-taiko-consensus"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives 0.8.25",
@@ -3794,7 +3794,7 @@ dependencies = [
 [[package]]
 name = "reth-taiko-evm"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 0.7.3",
@@ -3820,7 +3820,7 @@ dependencies = [
 [[package]]
 name = "reth-taiko-forks"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-chains 0.2.6",
  "alloy-primitives 0.8.25",
@@ -3830,7 +3830,7 @@ dependencies = [
 [[package]]
 name = "reth-taiko-primitives"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-primitives 0.8.25",
  "alloy-rlp",
@@ -3845,7 +3845,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "clap",
  "eyre",
@@ -3860,7 +3860,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 0.7.3",
@@ -3883,7 +3883,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -3904,7 +3904,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-primitives 0.8.25",
  "alloy-rlp",
@@ -3922,7 +3922,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "alloy-primitives 0.8.25",
  "alloy-rlp",
@@ -3937,7 +3937,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.1.4"
-source = "git+https://github.com/NethermindEth/surge-reth.git?tag=v1.1.4-surge#8d13cfa51e7c2ec6703c2e0b73ea7401dc3c1a48"
+source = "git+https://github.com/NethermindEth/surge-reth.git?branch=surge#3905aca450074d84ecd54398ea50ec6905c4bc07"
 dependencies = [
  "zstd",
 ]
@@ -4057,9 +4057,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11256b5fe8c68f56ac6f39ef0720e592f33d2367a4782740d9c9142e889c7fb4"
+checksum = "9ecb38f82477f20c5c3d62ef52d7c4e536e38ea9b73fb570a20c5cae0e14bcf6"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -5743,9 +5743,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
 dependencies = [
  "yoke",
  "zerofrom",

--- a/provers/sp1/guest/Cargo.toml
+++ b/provers/sp1/guest/Cargo.toml
@@ -57,7 +57,7 @@ revm-precompile = { git = "https://github.com/NethermindEth/surge-revm.git", tag
 
 
 bincode = "1.3.3"
-reth-primitives = { git = "https://github.com/NethermindEth/surge-reth.git", tag = "v1.1.4-surge", default-features = false, features = [
+reth-primitives = { git = "https://github.com/NethermindEth/surge-reth.git", branch = "surge", default-features = false, features = [
     "alloy-compat",
 ] }
 lazy_static = "1.5.0"


### PR DESCRIPTION
<h1> What's new </h1>

* Due to update in surge-taiko-mono, update of some sol types is needed
* `max_gas_issuance_per_block` type has been changed from u64 to u32