### PR TITLE
feat: sgx_any added

### DIFF
--- a/host/config/config.json
+++ b/host/config/config.json
@@ -24,5 +24,6 @@
   "native": {
     "json_guest_input": null
   },
-  "ballot": "{}"
+  "ballot_zk": "{\"Sp1\":1}",
+  "ballot_sgx": "{\"Sgx\":1}"
 }

--- a/host/src/bin/main.rs
+++ b/host/src/bin/main.rs
@@ -1,6 +1,7 @@
 #![allow(incomplete_features)]
 use raiko_host::{
-    interfaces::HostResult, parse_ballot, parse_chain_specs, parse_opts, server::serve,
+    interfaces::HostResult, parse_ballot_sgx, parse_ballot_zk, parse_chain_specs, parse_opts,
+    server::serve,
 };
 use raiko_reqpool::RedisPoolConfig;
 use std::path::PathBuf;
@@ -19,7 +20,8 @@ async fn main() -> HostResult<()> {
         .init();
     let opts = parse_opts()?;
     let chain_specs = parse_chain_specs(&opts);
-    let ballot = parse_ballot(&opts);
+    let ballot_zk = parse_ballot_zk(&opts);
+    let ballot_sgx = parse_ballot_sgx(&opts);
     let default_request_config = opts.proof_request_opt.clone();
     let max_proving_concurrency = opts.concurrency_limit;
     let pool = raiko_reqpool::Pool::open(RedisPoolConfig {
@@ -30,7 +32,8 @@ async fn main() -> HostResult<()> {
     .map_err(|e| anyhow::anyhow!(e))?;
     let actor = raiko_reqactor::start_actor(
         pool,
-        ballot,
+        ballot_zk,
+        ballot_sgx,
         chain_specs.clone(),
         default_request_config.clone(),
         max_proving_concurrency,

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -91,7 +91,16 @@ pub struct Opts {
         default_value = "{}",
         help = "e.g. {\"Sp1\":0.1,\"Risc0\":0.2}"
     )]
-    pub ballot: String,
+    pub ballot_zk: String,
+
+    /// Ballot config in json format. If not provided, '{}' will be used.
+    #[arg(
+        long,
+        require_equals = true,
+        default_value = "{}",
+        help = "e.g. {\"Sp1\":0.1,\"Risc0\":0.2}"
+    )]
+    pub ballot_sgx: String,
 }
 
 impl Opts {
@@ -169,9 +178,17 @@ pub fn parse_chain_specs(opts: &Opts) -> SupportedChainSpecs {
     }
 }
 
-pub fn parse_ballot(opts: &Opts) -> Ballot {
+pub fn parse_ballot_zk(opts: &Opts) -> Ballot {
     let probs: BTreeMap<ProofType, f64> =
-        serde_json::from_str(&opts.ballot).expect("Failed to parse ballot config");
+        serde_json::from_str(&opts.ballot_zk).expect("Failed to parse ballot config");
+    let ballot = Ballot::new(probs).expect("Failed to create ballot");
+    ballot.validate().expect("Failed to validate ballot");
+    ballot
+}
+
+pub fn parse_ballot_sgx(opts: &Opts) -> Ballot {
+    let probs: BTreeMap<ProofType, f64> =
+        serde_json::from_str(&opts.ballot_sgx).expect("Failed to parse ballot config");
     let ballot = Ballot::new(probs).expect("Failed to create ballot");
     ballot.validate().expect("Failed to validate ballot");
     ballot

--- a/host/src/server/api/admin.rs
+++ b/host/src/server/api/admin.rs
@@ -13,8 +13,10 @@ use raiko_reqactor::Actor;
 pub fn create_router() -> Router<Actor> {
     Router::new()
         .route("/pause", post(pause))
-        .route("/set_ballot", post(set_ballot))
-        .route("/get_ballot", get(get_ballot))
+        .route("/set_ballot_zk", post(set_ballot_zk))
+        .route("/get_ballot_zk", get(get_ballot_zk))
+        .route("/set_ballot_sgx", post(set_ballot_sgx))
+        .route("/get_ballot_sgx", get(get_ballot_sgx))
 }
 
 async fn pause(State(actor): State<Actor>) -> HostResult<&'static str> {
@@ -22,16 +24,30 @@ async fn pause(State(actor): State<Actor>) -> HostResult<&'static str> {
     Ok("System paused successfully")
 }
 
-async fn set_ballot(
+async fn set_ballot_zk(
     State(actor): State<Actor>,
     Json(probs): Json<BTreeMap<ProofType, f64>>,
 ) -> HostResult<&'static str> {
     let ballot = Ballot::new(probs).map_err(|e| anyhow::anyhow!(e))?;
-    actor.set_ballot(ballot);
+    actor.set_ballot_zk(ballot);
     Ok("Ballot set successfully")
 }
 
-async fn get_ballot(State(actor): State<Actor>) -> Response {
-    let ballot = actor.get_ballot().probabilities().to_owned();
+async fn get_ballot_zk(State(actor): State<Actor>) -> Response {
+    let ballot = actor.get_ballot_zk().probabilities().to_owned();
+    Json(ballot).into_response()
+}
+
+async fn set_ballot_sgx(
+    State(actor): State<Actor>,
+    Json(probs): Json<BTreeMap<ProofType, f64>>,
+) -> HostResult<&'static str> {
+    let ballot = Ballot::new(probs).map_err(|e| anyhow::anyhow!(e))?;
+    actor.set_ballot_sgx(ballot);
+    Ok("Ballot set successfully")
+}
+
+async fn get_ballot_sgx(State(actor): State<Actor>) -> Response {
+    let ballot = actor.get_ballot_sgx().probabilities().to_owned();
     Json(ballot).into_response()
 }

--- a/host/src/server/api/v1/proof.rs
+++ b/host/src/server/api/v1/proof.rs
@@ -11,7 +11,10 @@ use crate::{
     metrics::{inc_current_req, inc_guest_req_count, inc_host_req_count},
     server::{
         api::v1::Status,
-        utils::{draw_for_zk_any_request, is_zk_any_request, to_v1_status},
+        utils::{
+            draw_for_sgx_any_request, draw_for_zk_any_request, is_sgx_any_request,
+            is_zk_any_request, to_v1_status,
+        },
     },
 };
 
@@ -49,6 +52,18 @@ async fn proof_handler(
             None => {
                 return Err(
                     anyhow::anyhow!("Failed to draw zk_any proof type for block hash").into(),
+                );
+            }
+        }
+    }
+
+    // For sgx_any request, draw sgx proof type based on the block hash.
+    if is_sgx_any_request(&req) {
+        match draw_for_sgx_any_request(&actor, &serde_json::to_value(&config)?).await? {
+            Some(proof_type) => config.proof_type = Some(proof_type.to_string()),
+            None => {
+                return Err(
+                    anyhow::anyhow!("Failed to draw sgx_any proof type for block hash").into(),
                 );
             }
         }

--- a/reqactor/src/lib.rs
+++ b/reqactor/src/lib.rs
@@ -20,7 +20,8 @@ pub use raiko_reqpool::{
 /// Run the actor backend in background, and return the actor.
 pub async fn start_actor(
     pool: Pool,
-    ballot: Ballot,
+    ballot_zk: Ballot,
+    ballot_sgx: Ballot,
     chain_specs: SupportedChainSpecs,
     default_request_config: ProofRequestOpt,
     max_proving_concurrency: usize,
@@ -41,7 +42,8 @@ pub async fn start_actor(
 
     Actor::new(
         pool,
-        ballot,
+        ballot_zk,
+        ballot_sgx,
         default_request_config,
         chain_specs.clone(),
         action_tx,


### PR DESCRIPTION
<h1> What's new </h1>

* `sgx_any` added (analog for `zk_any` ballot)
* `config.json` updated:
    - `ballot` filed renamed to `ballot_zk`
    - `ballot_sgx` added
   
As `zk_any`, `sgx_any` intended to be used for `randomized` choice of sgx provers: `sgx` or `sgx_geth`  