### PR TITLE
Refactor CI/CD Workflows for Raiko Client SGX & SP1 Docker Builds

### DIFF
--- a/.github/workflows/raiko-client-sgx--docker-build.yml
+++ b/.github/workflows/raiko-client-sgx--docker-build.yml
@@ -48,8 +48,8 @@ jobs:
           username: ${{ secrets.ARTIFACTORY_CORE_USERNAME }}
           password: ${{ secrets.ARTIFACTORY_CORE_TOKEN_DEVELOPER }}
 
-      - name: Docker meta for dev
-        id: meta-dev
+      - name: Docker meta for staging
+        id: meta-staging
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPOSITORY_STAGING }}
@@ -65,8 +65,8 @@ jobs:
           file: ./Dockerfile
           platforms: ${{ matrix.platform }}
           push: true
-          tags: ${{ steps.meta-dev.outputs.tags }}
-          labels: ${{ steps.meta-dev.outputs.labels }}
+          tags: ${{ steps.meta-staging.outputs.tags }}
+          labels: ${{ steps.meta-staging.outputs.labels }}
 
       - name: Set digest output
         id: digest

--- a/.github/workflows/raiko-client-sgx--docker-build.yml
+++ b/.github/workflows/raiko-client-sgx--docker-build.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   build:
-    name: Build and push docker image
+    name: Build and push docker image to Staging
     runs-on: ubuntu-latest
     if: github.repository == 'NethermindEth/raiko'
     strategy:
@@ -74,33 +74,10 @@ jobs:
           echo "amd64=${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPOSITORY_STAGING }}@${{ steps.build.outputs.digest }}" >> $GITHUB_OUTPUT
 
   merge:
-    name: Create manifest and promote to staging
+    name: Create manifest and promote to Production
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: docker/login-action@v3
-        with:
-          registry: ${{ env.DOCKER_REGISTRY }}
-          username: ${{ secrets.ARTIFACTORY_CORE_USERNAME }}
-          password: ${{ secrets.ARTIFACTORY_CORE_TOKEN_DEVELOPER }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPOSITORY_STAGING }}
-          tags: |
-            type=raw,value=latest
-            type=ref,event=tag
-
-      - name: Create manifest list and push
-        run: |
-          docker buildx imagetools create \
-            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            ${{ needs.build.outputs.digest-amd64 }}
 
       - name: Setup ORAS
         uses: oras-project/setup-oras@v1
@@ -111,17 +88,25 @@ jobs:
       - name: Login to registry with ORAS
         run: |
           oras login ${{ env.DOCKER_REGISTRY }} \
-            -u ${{ env.ARTIFACTORY_CORE_USERNAME }} \
+            -u ${{ secrets.ARTIFACTORY_CORE_USERNAME }} \
             -p ${{ secrets.ARTIFACTORY_CORE_TOKEN_DEVELOPER }}
 
-      - name: Promote to Staging
+      - name: Determine tags to promote
+        id: promote-tags
         run: |
-          echo "${{ steps.meta.outputs.tags }}" | while IFS= read -r tag; do
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+            echo "TAGS=latest $VERSION" >> $GITHUB_ENV
+          else
+            echo "TAGS=latest" >> $GITHUB_ENV
+          fi
+
+      - name: Promote to PROD
+        run: |
+          for tag in $TAGS; do
             echo "Current tag: $tag"
-            tag=$(echo "$tag" | xargs)
-            tag_suffix="${tag##*:}"
-            source_image="${DOCKER_REGISTRY}/${DOCKER_REPOSITORY_STAGING}:${tag_suffix}"
-            prod_image="${DOCKER_REGISTRY}/${DOCKER_REPOSITORY_PROD}:${tag_suffix}"
+            source_image="${DOCKER_REGISTRY}/${DOCKER_REPOSITORY_STAGING}:${tag}"
+            prod_image="${DOCKER_REGISTRY}/${DOCKER_REPOSITORY_PROD}:${tag}"
             echo "Promoting ${source_image} to ${prod_image}"
             oras cp -r "${source_image}" "${prod_image}"
           done
@@ -130,8 +115,8 @@ jobs:
         run: |
           echo "## SGX Docker build completed ✅" >> $GITHUB_STEP_SUMMARY
           echo "### Tags" >> $GITHUB_STEP_SUMMARY
-          echo "${{ steps.meta.outputs.tags }}" | while IFS= read -r TAG; do
-            echo "- $TAG" >> $GITHUB_STEP_SUMMARY
+          for tag in $TAGS; do
+            echo "- $tag" >> $GITHUB_STEP_SUMMARY
           done
           echo "### Notes" >> $GITHUB_STEP_SUMMARY
           echo "- The images have been pushed to ${DOCKER_REPOSITORY_STAGING} repo" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/raiko-client-sp1--docker-build.yml
+++ b/.github/workflows/raiko-client-sp1--docker-build.yml
@@ -48,8 +48,8 @@ jobs:
           username: ${{ secrets.ARTIFACTORY_CORE_USERNAME }}
           password: ${{ secrets.ARTIFACTORY_CORE_TOKEN_DEVELOPER }}
 
-      - name: Docker meta for dev
-        id: meta-dev
+      - name: Docker meta for staging
+        id: meta-staging
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPOSITORY_STAGING }}
@@ -65,8 +65,8 @@ jobs:
           file: ./Dockerfile.zk
           platforms: ${{ matrix.platform }}
           push: true
-          tags: ${{ steps.meta-dev.outputs.tags }}
-          labels: ${{ steps.meta-dev.outputs.labels }}
+          tags: ${{ steps.meta-staging.outputs.tags }}
+          labels: ${{ steps.meta-staging.outputs.labels }}
 
       - name: Set digest output
         id: digest

--- a/.github/workflows/raiko-client-sp1--docker-build.yml
+++ b/.github/workflows/raiko-client-sp1--docker-build.yml
@@ -74,34 +74,10 @@ jobs:
           echo "amd64=${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPOSITORY_STAGING }}@${{ steps.build.outputs.digest }}" >> $GITHUB_OUTPUT
 
   merge:
-    name: Create manifest and promote to staging
+    name: Create manifest and promote to Production
     runs-on: [self-hosted, linux, x64]  # Custom runner
     needs: build
     steps:
-      - uses: docker/login-action@v3
-        with:
-          registry: ${{ env.DOCKER_REGISTRY }}
-          username: ${{ secrets.ARTIFACTORY_CORE_USERNAME }}
-          password: ${{ secrets.ARTIFACTORY_CORE_TOKEN_DEVELOPER }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REPOSITORY_STAGING }}
-          tags: |
-            type=raw,value=latest
-            type=ref,event=tag
-
-      - name: Create manifest list and push
-        run: |
-          docker buildx imagetools create \
-            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            ${{ needs.build.outputs.digest-amd64 }}
-
       - name: Setup ORAS
         uses: oras-project/setup-oras@v1
 
@@ -111,27 +87,25 @@ jobs:
       - name: Login to registry with ORAS
         run: |
           oras login ${{ env.DOCKER_REGISTRY }} \
-            -u ${{ env.ARTIFACTORY_CORE_USERNAME }} \
+            -u ${{ secrets.ARTIFACTORY_CORE_USERNAME }} \
             -p ${{ secrets.ARTIFACTORY_CORE_TOKEN_DEVELOPER }}
 
-      - name: Promote to Staging
+      - name: Promote to PROD
         run: |
-          echo "${{ steps.meta.outputs.tags }}" | while IFS= read -r tag; do
+          for tag in $TAGS; do
             echo "Current tag: $tag"
-            tag=$(echo "$tag" | xargs)
-            tag_suffix="${tag##*:}"
-            source_image="${DOCKER_REGISTRY}/${DOCKER_REPOSITORY_STAGING}:${tag_suffix}"
-            prod_image="${DOCKER_REGISTRY}/${DOCKER_REPOSITORY_PROD}:${tag_suffix}"
+            source_image="${DOCKER_REGISTRY}/${DOCKER_REPOSITORY_STAGING}:${tag}"
+            prod_image="${DOCKER_REGISTRY}/${DOCKER_REPOSITORY_PROD}:${tag}"
             echo "Promoting ${source_image} to ${prod_image}"
             oras cp -r "${source_image}" "${prod_image}"
           done
 
       - name: Summary
         run: |
-          echo "## SP1 Docker build completed ✅" >> $GITHUB_STEP_SUMMARY
+          echo "## SGX Docker build completed ✅" >> $GITHUB_STEP_SUMMARY
           echo "### Tags" >> $GITHUB_STEP_SUMMARY
-          echo "${{ steps.meta.outputs.tags }}" | while IFS= read -r TAG; do
-            echo "- $TAG" >> $GITHUB_STEP_SUMMARY
+          for tag in $TAGS; do
+            echo "- $tag" >> $GITHUB_STEP_SUMMARY
           done
           echo "### Notes" >> $GITHUB_STEP_SUMMARY
           echo "- The images have been pushed to ${DOCKER_REPOSITORY_STAGING} repo" >> $GITHUB_STEP_SUMMARY

--- a/docker/docker-compose-zk.yml
+++ b/docker/docker-compose-zk.yml
@@ -1,6 +1,6 @@
 services:
   raiko-zk:
-    image: nethermind.jfrog.io/core-oci-local-staging/raiko-zk:v2
+    image: nethermind.jfrog.io/core-oci-local-staging/raiko-zk:latest
     container_name: raiko-zk
     network_mode: host
     env_file:
@@ -8,14 +8,17 @@ services:
     environment:
       ZK: "true"
       SP1_PLONK_CIRCUIT_PATH: "${HOME}/.sp1/circuits/plonk"
+      RAIKO_CONF_DIR: "/raiko/config"
+      BASE_CONFIG_FILE: "config.json"
+      BASE_CHAINSPEC_FILE: "chain_spec_list_devnet.json"
     runtime: nvidia
     privileged: true
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - ../host/config:/etc/config
+      - ../host/config:/raiko/config
       - /tmp:/tmp
     depends_on:
-      - redis
+      - redis-zk
   redis-zk:
     image: redis
     container_name: redis-zk


### PR DESCRIPTION
Key Changes

Separate Workflows: Maintains distinct workflows for SGX (raiko-client-sgx--docker-build.yml) and SP1 (raiko-client-sp1--docker-build.yml) Docker builds.

Trigger Conditions: Both workflows are triggered on pushes to main, relevant tags (v*-sgx for SGX, v*-sp1 for SP1), and manual dispatch. Fix the image promotion from staging to prod.