### PR TITLE
fix: prevent panic on realtime polling requests with empty sources

### DIFF
--- a/core/src/interfaces.rs
+++ b/core/src/interfaces.rs
@@ -950,9 +950,6 @@ pub struct RealTimeProofRequest {
     pub blobs: Vec<String>,
     /// Previous finalized checkpoint
     pub checkpoint: Option<ShastaProposalCheckpoint>,
-    /// If true, return cached proof if available. If false (default), always re-prove.
-    #[serde(default)]
-    pub use_cache: bool,
 }
 
 #[serde_as]
@@ -983,9 +980,6 @@ pub struct RealTimeProofRequestOpt {
     #[serde(default)]
     pub blobs: Vec<String>,
     pub checkpoint: Option<ShastaProposalCheckpoint>,
-    /// If true, return cached proof if available. If false (default), always re-prove.
-    #[serde(default)]
-    pub use_cache: bool,
 }
 
 impl TryFrom<RealTimeProofRequestOpt> for RealTimeProofRequest {
@@ -1031,7 +1025,6 @@ impl TryFrom<RealTimeProofRequestOpt> for RealTimeProofRequest {
             sources: value.sources,
             blobs: value.blobs,
             checkpoint: value.checkpoint,
-            use_cache: value.use_cache,
         })
     }
 }

--- a/core/src/interfaces.rs
+++ b/core/src/interfaces.rs
@@ -916,6 +916,10 @@ impl TryFrom<ShastaProofRequestOpt> for ShastaProofRequest {
 
 // === RealTime fork request types ===
 
+fn default_use_cache() -> bool {
+    true
+}
+
 #[serde_as]
 #[derive(Clone, Debug, Serialize, Deserialize, ToSchema)]
 pub struct RealTimeProofRequest {
@@ -950,6 +954,9 @@ pub struct RealTimeProofRequest {
     pub blobs: Vec<String>,
     /// Previous finalized checkpoint
     pub checkpoint: Option<ShastaProposalCheckpoint>,
+    /// If true (default), return cached proof if available. If false, force re-proving.
+    #[serde(default = "default_use_cache")]
+    pub use_cache: bool,
 }
 
 #[serde_as]
@@ -980,6 +987,9 @@ pub struct RealTimeProofRequestOpt {
     #[serde(default)]
     pub blobs: Vec<String>,
     pub checkpoint: Option<ShastaProposalCheckpoint>,
+    /// If true (default), return cached proof if available. If false, force re-proving.
+    #[serde(default = "default_use_cache")]
+    pub use_cache: bool,
 }
 
 impl TryFrom<RealTimeProofRequestOpt> for RealTimeProofRequest {
@@ -1025,6 +1035,7 @@ impl TryFrom<RealTimeProofRequestOpt> for RealTimeProofRequest {
             sources: value.sources,
             blobs: value.blobs,
             checkpoint: value.checkpoint,
+            use_cache: value.use_cache,
         })
     }
 }

--- a/core/src/interfaces.rs
+++ b/core/src/interfaces.rs
@@ -924,6 +924,9 @@ fn default_use_cache() -> bool {
 #[derive(Clone, Debug, Serialize, Deserialize, ToSchema)]
 pub struct RealTimeProofRequest {
     pub l2_block_numbers: Vec<u64>,
+    /// Block hashes corresponding to l2_block_numbers, used as part of the cache key.
+    #[serde(default)]
+    pub l2_block_hashes: Vec<B256>,
     pub proof_type: ProofType,
 
     pub network: String,
@@ -964,6 +967,8 @@ pub struct RealTimeProofRequest {
 pub struct RealTimeProofRequestOpt {
     // Required fields
     pub l2_block_numbers: Vec<u64>,
+    #[serde(default)]
+    pub l2_block_hashes: Vec<B256>,
     pub proof_type: String,
 
     // Optional fields, if not provided, the default values will be used
@@ -998,6 +1003,7 @@ impl TryFrom<RealTimeProofRequestOpt> for RealTimeProofRequest {
     fn try_from(value: RealTimeProofRequestOpt) -> Result<Self, Self::Error> {
         Ok(Self {
             l2_block_numbers: value.l2_block_numbers,
+            l2_block_hashes: value.l2_block_hashes,
             proof_type: value
                 .proof_type
                 .parse()

--- a/host/src/server/api/v3/proof/batch/mod.rs
+++ b/host/src/server/api/v3/proof/batch/mod.rs
@@ -2,5 +2,5 @@ pub mod pacaya;
 pub mod realtime;
 pub mod shasta;
 pub use pacaya::process_pacaya_batch;
-pub use realtime::process_realtime_request;
+pub use realtime::{make_proof_request_key, process_realtime_request};
 pub use shasta::process_shasta_batch;

--- a/host/src/server/api/v3/proof/batch/realtime.rs
+++ b/host/src/server/api/v3/proof/batch/realtime.rs
@@ -67,6 +67,23 @@ fn create_realtime_requests(
     )
 }
 
+/// Build only the proof request key for status lookups (polling).
+pub fn make_proof_request_key(request: &RealTimeProofRequest, image_id: &ImageId) -> RequestKey {
+    let actual_prover_address = request.prover.to_string();
+    RequestKey::RealTimeProof(RealTimeProofRequestKey::new_with_input_key_and_image_id(
+        RealTimeInputRequestKey::new(
+            request.l2_block_numbers.clone(),
+            request.l2_block_hashes.clone(),
+            request.l1_network.clone(),
+            request.network.clone(),
+            request.last_finalized_block_hash,
+        ),
+        request.proof_type,
+        actual_prover_address,
+        image_id.clone(),
+    ))
+}
+
 /// Process a RealTime request and return the necessary data for the handler.
 /// Unlike Shasta, there is exactly one proposal per request (no batching).
 pub fn process_realtime_request(

--- a/host/src/server/api/v3/proof/batch/realtime.rs
+++ b/host/src/server/api/v3/proof/batch/realtime.rs
@@ -1,4 +1,3 @@
-use alloy_primitives::B256;
 use raiko_core::interfaces::RealTimeProofRequest;
 use raiko_reqpool::{
     ImageId, RealTimeInputRequestEntity, RealTimeInputRequestKey, RealTimeProofRequestEntity,
@@ -9,7 +8,6 @@ use raiko_reqpool::{
 fn create_realtime_requests(
     request: &RealTimeProofRequest,
     image_id: &ImageId,
-    l2_block_hashes: Vec<B256>,
 ) -> (
     RequestKey,
     RequestKey,
@@ -19,7 +17,7 @@ fn create_realtime_requests(
     // RealTime: one proposal per request, no batching
     let input_request_key = RequestKey::RealTimeGuestInput(RealTimeInputRequestKey::new(
         request.l2_block_numbers.clone(),
-        l2_block_hashes.clone(),
+        request.l2_block_hashes.clone(),
         request.l1_network.clone(),
         request.network.clone(),
         request.last_finalized_block_hash,
@@ -30,7 +28,7 @@ fn create_realtime_requests(
         RequestKey::RealTimeProof(RealTimeProofRequestKey::new_with_input_key_and_image_id(
             RealTimeInputRequestKey::new(
                 request.l2_block_numbers.clone(),
-                l2_block_hashes,
+                request.l2_block_hashes.clone(),
                 request.l1_network.clone(),
                 request.network.clone(),
                 request.last_finalized_block_hash,
@@ -74,7 +72,6 @@ fn create_realtime_requests(
 pub fn process_realtime_request(
     request: &RealTimeProofRequest,
     image_id: &ImageId,
-    l2_block_hashes: Vec<B256>,
 ) -> (
     RequestKey,
     RequestKey,
@@ -82,7 +79,7 @@ pub fn process_realtime_request(
     raiko_reqpool::RequestEntity,
 ) {
     let (input_key, proof_key, input_entity, proof_entity) =
-        create_realtime_requests(request, image_id, l2_block_hashes);
+        create_realtime_requests(request, image_id);
 
     (
         input_key,

--- a/host/src/server/api/v3/proof/batch/realtime.rs
+++ b/host/src/server/api/v3/proof/batch/realtime.rs
@@ -1,3 +1,4 @@
+use alloy_primitives::B256;
 use raiko_core::interfaces::RealTimeProofRequest;
 use raiko_reqpool::{
     ImageId, RealTimeInputRequestEntity, RealTimeInputRequestKey, RealTimeProofRequestEntity,
@@ -8,6 +9,7 @@ use raiko_reqpool::{
 fn create_realtime_requests(
     request: &RealTimeProofRequest,
     image_id: &ImageId,
+    l2_block_hashes: Vec<B256>,
 ) -> (
     RequestKey,
     RequestKey,
@@ -17,6 +19,7 @@ fn create_realtime_requests(
     // RealTime: one proposal per request, no batching
     let input_request_key = RequestKey::RealTimeGuestInput(RealTimeInputRequestKey::new(
         request.l2_block_numbers.clone(),
+        l2_block_hashes.clone(),
         request.l1_network.clone(),
         request.network.clone(),
         request.last_finalized_block_hash,
@@ -27,6 +30,7 @@ fn create_realtime_requests(
         RequestKey::RealTimeProof(RealTimeProofRequestKey::new_with_input_key_and_image_id(
             RealTimeInputRequestKey::new(
                 request.l2_block_numbers.clone(),
+                l2_block_hashes,
                 request.l1_network.clone(),
                 request.network.clone(),
                 request.last_finalized_block_hash,
@@ -70,6 +74,7 @@ fn create_realtime_requests(
 pub fn process_realtime_request(
     request: &RealTimeProofRequest,
     image_id: &ImageId,
+    l2_block_hashes: Vec<B256>,
 ) -> (
     RequestKey,
     RequestKey,
@@ -77,7 +82,7 @@ pub fn process_realtime_request(
     raiko_reqpool::RequestEntity,
 ) {
     let (input_key, proof_key, input_entity, proof_entity) =
-        create_realtime_requests(request, image_id);
+        create_realtime_requests(request, image_id, l2_block_hashes);
 
     (
         input_key,

--- a/host/src/server/api/v3/proof/realtime_handler.rs
+++ b/host/src/server/api/v3/proof/realtime_handler.rs
@@ -121,18 +121,6 @@ async fn realtime_handler(
         serde_json::to_string(&realtime_request)?,
     );
 
-    // Fetch L2 block hashes from RPC to use as part of the cache key.
-    let mut l2_block_hashes = Vec::with_capacity(realtime_request.l2_block_numbers.len());
-    for &block_number in &realtime_request.l2_block_numbers {
-        let (_, block_hash) = raiko_core::provider::get_task_data(
-            &realtime_request.network,
-            block_number,
-            actor.chain_specs(),
-        )
-        .await?;
-        l2_block_hashes.push(block_hash);
-    }
-
     // No aggregation for RealTime
     let image_id = ImageId::from_proof_type_and_request_type(&realtime_request.proof_type, false);
 
@@ -142,7 +130,7 @@ async fn realtime_handler(
     if realtime_request.sources.is_empty() {
         // Build only the key needed for status lookup, skip full entity construction.
         let (_input_request_key, proof_request_key, _input_request_entity, _) =
-            process_realtime_request(&realtime_request, &image_id, l2_block_hashes);
+            process_realtime_request(&realtime_request, &image_id);
 
         let result = actor.pool_get_status(&proof_request_key.into()).await;
         let status = match result {
@@ -165,7 +153,7 @@ async fn realtime_handler(
     }
 
     let (_input_request_key, proof_request_key, _input_request_entity, proof_request_entity) =
-        process_realtime_request(&realtime_request, &image_id, l2_block_hashes);
+        process_realtime_request(&realtime_request, &image_id);
 
     // If use_cache is false, evict existing proof to force re-proving.
     if !realtime_request.use_cache {

--- a/host/src/server/api/v3/proof/realtime_handler.rs
+++ b/host/src/server/api/v3/proof/realtime_handler.rs
@@ -121,11 +121,23 @@ async fn realtime_handler(
         serde_json::to_string(&realtime_request)?,
     );
 
+    // Fetch L2 block hashes from RPC to use as part of the cache key.
+    let mut l2_block_hashes = Vec::with_capacity(realtime_request.l2_block_numbers.len());
+    for &block_number in &realtime_request.l2_block_numbers {
+        let (_, block_hash) = raiko_core::provider::get_task_data(
+            &realtime_request.network,
+            block_number,
+            actor.chain_specs(),
+        )
+        .await?;
+        l2_block_hashes.push(block_hash);
+    }
+
     // No aggregation for RealTime
     let image_id = ImageId::from_proof_type_and_request_type(&realtime_request.proof_type, false);
 
     let (_input_request_key, proof_request_key, _input_request_entity, proof_request_entity) =
-        process_realtime_request(&realtime_request, &image_id);
+        process_realtime_request(&realtime_request, &image_id, l2_block_hashes);
 
     // When sources is empty, this is a status poll — don't submit for proving.
     // The caller sends the first request with full sources+blobs to kick off proving,

--- a/host/src/server/api/v3/proof/realtime_handler.rs
+++ b/host/src/server/api/v3/proof/realtime_handler.rs
@@ -136,18 +136,15 @@ async fn realtime_handler(
     // No aggregation for RealTime
     let image_id = ImageId::from_proof_type_and_request_type(&realtime_request.proof_type, false);
 
-    let (_input_request_key, proof_request_key, _input_request_entity, proof_request_entity) =
-        process_realtime_request(&realtime_request, &image_id, l2_block_hashes);
-
     // When sources is empty, this is a status poll — don't submit for proving.
     // The caller sends the first request with full sources+blobs to kick off proving,
     // then polls with empty sources to check progress.
-    let is_poll = realtime_request.sources.is_empty();
+    if realtime_request.sources.is_empty() {
+        // Build only the key needed for status lookup, skip full entity construction.
+        let (_input_request_key, proof_request_key, _input_request_entity, _) =
+            process_realtime_request(&realtime_request, &image_id, l2_block_hashes);
 
-    if is_poll {
-        let result = actor
-            .pool_get_status(&proof_request_key.clone().into())
-            .await;
+        let result = actor.pool_get_status(&proof_request_key.into()).await;
         let status = match result {
             Ok(Some(status_with_context)) => to_v3_status(
                 realtime_request.proof_type,
@@ -155,17 +152,20 @@ async fn realtime_handler(
                 Ok(status_with_context.into_status()),
             ),
             Ok(None) => {
-                // No status found — proof expired via Redis TTL or never submitted
+                // No status found — proof expired or never submitted.
                 to_v3_status(
                     realtime_request.proof_type,
                     None,
-                    Ok(raiko_reqpool::Status::Registered),
+                    Err("proof not found: expired or never submitted".to_string()),
                 )
             }
             Err(e) => to_v3_status(realtime_request.proof_type, None, Err(e)),
         };
         return Ok(status);
     }
+
+    let (_input_request_key, proof_request_key, _input_request_entity, proof_request_entity) =
+        process_realtime_request(&realtime_request, &image_id, l2_block_hashes);
 
     // If use_cache is false, evict existing proof to force re-proving.
     if !realtime_request.use_cache {
@@ -177,12 +177,7 @@ async fn realtime_handler(
     // Submit proof directly — do_prove_realtime will generate guest input
     // inline if it's not already in prover_args, so no separate guest input
     // stage is needed.
-    let result = prove(
-        &actor,
-        proof_request_key.clone().into(),
-        proof_request_entity,
-    )
-    .await;
+    let result = prove(&actor, proof_request_key.into(), proof_request_entity).await;
 
     let status = to_v3_status(realtime_request.proof_type, None, result);
     Ok(status)

--- a/host/src/server/api/v3/proof/realtime_handler.rs
+++ b/host/src/server/api/v3/proof/realtime_handler.rs
@@ -127,22 +127,43 @@ async fn realtime_handler(
     let (_input_request_key, proof_request_key, _input_request_entity, proof_request_entity) =
         process_realtime_request(&realtime_request, &image_id);
 
+    // When sources is empty, this is a status poll — don't submit for proving.
+    // The caller sends the first request with full sources+blobs to kick off proving,
+    // then polls with empty sources to check progress.
+    let is_poll = realtime_request.sources.is_empty();
+
+    if is_poll {
+        let result = actor
+            .pool_get_status(&proof_request_key.clone().into())
+            .await;
+        let status = match result {
+            Ok(Some(status_with_context)) => to_v3_status(
+                realtime_request.proof_type,
+                None,
+                Ok(status_with_context.into_status()),
+            ),
+            Ok(None) => {
+                // No status found — proof expired via Redis TTL or never submitted
+                to_v3_status(
+                    realtime_request.proof_type,
+                    None,
+                    Ok(raiko_reqpool::Status::Registered),
+                )
+            }
+            Err(e) => to_v3_status(realtime_request.proof_type, None, Err(e)),
+        };
+        return Ok(status);
+    }
+
     // Submit proof directly — do_prove_realtime will generate guest input
     // inline if it's not already in prover_args, so no separate guest input
     // stage is needed.
-    let result = prove(&actor, proof_request_key.clone().into(), proof_request_entity).await;
-
-    // If use_cache is false, evict the proof AFTER returning Success to the
-    // caller — so the next request re-proves from scratch instead of serving
-    // the cached result. Evicting before prove() would mean the caller never
-    // sees Success (each poll would re-submit and return Registered).
-    if !realtime_request.use_cache {
-        if matches!(result, Ok(raiko_reqpool::Status::Success { .. })) {
-            if let Err(e) = actor.pool_remove_request(&proof_request_key.into()).await {
-                tracing::warn!("Failed to evict cached proof for re-proving: {e}");
-            }
-        }
-    }
+    let result = prove(
+        &actor,
+        proof_request_key.clone().into(),
+        proof_request_entity,
+    )
+    .await;
 
     let status = to_v3_status(realtime_request.proof_type, None, result);
     Ok(status)

--- a/host/src/server/api/v3/proof/realtime_handler.rs
+++ b/host/src/server/api/v3/proof/realtime_handler.rs
@@ -155,6 +155,13 @@ async fn realtime_handler(
         return Ok(status);
     }
 
+    // If use_cache is false, evict existing proof to force re-proving.
+    if !realtime_request.use_cache {
+        let _ = actor
+            .pool_remove_request(&proof_request_key.clone().into())
+            .await;
+    }
+
     // Submit proof directly — do_prove_realtime will generate guest input
     // inline if it's not already in prover_args, so no separate guest input
     // stage is needed.

--- a/host/src/server/api/v3/proof/realtime_handler.rs
+++ b/host/src/server/api/v3/proof/realtime_handler.rs
@@ -22,7 +22,7 @@ use raiko_tasks::TaskStatus;
 use serde_json::Value;
 use utoipa::OpenApi;
 
-use super::batch::process_realtime_request;
+use super::batch::{make_proof_request_key, process_realtime_request};
 
 #[utoipa::path(post, path = "/batch/realtime",
     tag = "Proving",
@@ -128,11 +128,8 @@ async fn realtime_handler(
     // The caller sends the first request with full sources+blobs to kick off proving,
     // then polls with empty sources to check progress.
     if realtime_request.sources.is_empty() {
-        // Build only the key needed for status lookup, skip full entity construction.
-        let (_input_request_key, proof_request_key, _input_request_entity, _) =
-            process_realtime_request(&realtime_request, &image_id);
-
-        let result = actor.pool_get_status(&proof_request_key.into()).await;
+        let proof_request_key = make_proof_request_key(&realtime_request, &image_id);
+        let result = actor.pool_get_status(&proof_request_key).await;
         let status = match result {
             Ok(Some(status_with_context)) => to_v3_status(
                 realtime_request.proof_type,

--- a/host/src/server/api/v3/proof/realtime_handler.rs
+++ b/host/src/server/api/v3/proof/realtime_handler.rs
@@ -144,7 +144,7 @@ async fn realtime_handler(
                 to_v3_status(
                     realtime_request.proof_type,
                     None,
-                    Err("proof not found: expired or never submitted".to_string()),
+                    Err("proof not found: expired or never submitted. Ensure l2_block_hashes matches the original submit request.".to_string()),
                 )
             }
             Err(e) => to_v3_status(realtime_request.proof_type, None, Err(e)),

--- a/lib/src/primitives/eip4844.rs
+++ b/lib/src/primitives/eip4844.rs
@@ -20,7 +20,7 @@ pub mod trusted_setup_gen {
 }
 
 // The KZG settings under the concrete type of kzg backend
-// We directly include the serialzed struct generated from build.rs to avoid conversion cost in guest
+// We directly include the serialized struct generated from build.rs to avoid conversion cost in guest
 pub static KZG_SETTINGS: Lazy<KZGSettings> = Lazy::new(|| trusted_setup_gen::prebuilt_settings());
 
 pub const VERSIONED_HASH_VERSION_KZG: u8 = 0x01;

--- a/reqpool/src/memory_backend.rs
+++ b/reqpool/src/memory_backend.rs
@@ -236,4 +236,63 @@ mod tests {
             assert_eq!(actual, Ok(format!("val{}", i)));
         }
     }
+
+    #[test]
+    fn test_memory_pool_ttl_expiry() {
+        let mut pool = memory_pool("test_memory_pool_ttl_expiry");
+        let mut conn = pool.conn().expect("memory conn");
+
+        let key = "ttl_key".to_string();
+        let val = "ttl_val".to_string();
+        conn.set_ex(key.clone(), val.clone(), 1).expect("set_ex");
+
+        // Value should be accessible before TTL expires
+        let actual: RedisResult<String> = conn.get(&key);
+        assert_eq!(actual, Ok(val));
+
+        // Wait for TTL to expire
+        std::thread::sleep(Duration::from_secs(2));
+
+        // Value should be gone after TTL
+        let actual: RedisResult<String> = conn.get(&key);
+        assert!(actual.is_err());
+    }
+
+    #[test]
+    fn test_memory_pool_ttl_zero_no_expiry() {
+        let mut pool = memory_pool("test_memory_pool_ttl_zero");
+        let mut conn = pool.conn().expect("memory conn");
+
+        let key = "no_expiry".to_string();
+        let val = "persistent".to_string();
+        conn.set_ex(key.clone(), val.clone(), 0).expect("set_ex");
+
+        std::thread::sleep(Duration::from_secs(2));
+
+        // ttl=0 means no expiry — value should still be accessible
+        let actual: RedisResult<String> = conn.get(&key);
+        assert_eq!(actual, Ok(val));
+    }
+
+    #[test]
+    fn test_memory_pool_keys_filters_expired() {
+        let mut pool = memory_pool("test_memory_pool_keys_expired");
+        let mut conn = pool.conn().expect("memory conn");
+
+        conn.set_ex("live".to_string(), "val1".to_string(), 0)
+            .expect("set_ex");
+        conn.set_ex("expiring".to_string(), "val2".to_string(), 1)
+            .expect("set_ex");
+
+        // Both keys should be present before expiry
+        let keys: Vec<String> = conn.keys("*").expect("keys");
+        assert_eq!(keys.len(), 2);
+
+        std::thread::sleep(Duration::from_secs(2));
+
+        // Only the live key should remain
+        let keys: Vec<String> = conn.keys("*").expect("keys");
+        assert_eq!(keys.len(), 1);
+        assert!(keys.contains(&"live".to_string()));
+    }
 }

--- a/reqpool/src/memory_backend.rs
+++ b/reqpool/src/memory_backend.rs
@@ -7,11 +7,19 @@ use std::{
     collections::HashMap,
     num::NonZeroUsize,
     sync::{Arc, Mutex},
+    time::{Duration, Instant},
 };
 
 use lru::LruCache;
 
-type SingleStorage = Arc<Mutex<LruCache<Value, Value>>>;
+/// A value with an optional expiry time.
+#[derive(Clone)]
+struct Entry {
+    value: Value,
+    expires_at: Option<Instant>,
+}
+
+type SingleStorage = Arc<Mutex<LruCache<Value, Entry>>>;
 type GlobalStorage = Mutex<HashMap<String, SingleStorage>>;
 
 lazy_static! {
@@ -50,24 +58,41 @@ impl MemoryBackend {
         &mut self,
         key: K,
         val: V,
-        _ttl: u64,
+        ttl: u64,
     ) -> RedisResult<()> {
         let mut lock = self.storage.lock().unwrap();
-        lock.put(json!(key), json!(val));
+        let entry = Entry {
+            value: json!(val),
+            expires_at: if ttl > 0 {
+                Some(Instant::now() + Duration::from_secs(ttl))
+            } else {
+                None
+            },
+        };
+        lock.put(json!(key), entry);
         Ok(())
     }
 
     pub fn get<K: Serialize, V: serde::de::DeserializeOwned>(&mut self, key: &K) -> RedisResult<V> {
         let mut lock = self.storage.lock().unwrap();
-        match lock.get(&json!(key)) {
+        let json_key = json!(key);
+        match lock.get(&json_key) {
             None => Err(RedisError::from((redis::ErrorKind::TypeError, "not found"))),
-            Some(v) => serde_json::from_value(v.clone()).map_err(|e| {
-                RedisError::from((
-                    redis::ErrorKind::TypeError,
-                    "deserialization error",
-                    e.to_string(),
-                ))
-            }),
+            Some(entry) => {
+                if let Some(expires_at) = entry.expires_at {
+                    if Instant::now() >= expires_at {
+                        lock.pop(&json_key);
+                        return Err(RedisError::from((redis::ErrorKind::TypeError, "not found")));
+                    }
+                }
+                serde_json::from_value(entry.value.clone()).map_err(|e| {
+                    RedisError::from((
+                        redis::ErrorKind::TypeError,
+                        "deserialization error",
+                        e.to_string(),
+                    ))
+                })
+            }
         }
     }
 
@@ -83,7 +108,17 @@ impl MemoryBackend {
     pub fn keys<K: serde::de::DeserializeOwned>(&mut self, key: &str) -> RedisResult<Vec<K>> {
         assert_eq!(key, "*", "memory backend only supports '*'");
 
-        let lock = self.storage.lock().unwrap();
+        let mut lock = self.storage.lock().unwrap();
+        let now = Instant::now();
+        // Collect expired keys first to avoid borrow issues
+        let expired: Vec<Value> = lock
+            .iter()
+            .filter(|(_, entry)| entry.expires_at.map_or(false, |exp| now >= exp))
+            .map(|(k, _)| k.clone())
+            .collect();
+        for k in expired {
+            lock.pop(&k);
+        }
         Ok(lock
             .iter()
             .map(|(k, _)| serde_json::from_value(k.clone()).unwrap())

--- a/reqpool/src/request.rs
+++ b/reqpool/src/request.rs
@@ -421,6 +421,8 @@ impl ShastaProofRequestKey {
 pub struct RealTimeInputRequestKey {
     /// The L2 block numbers covered by this request
     l2_block_numbers: Vec<u64>,
+    /// The L2 block hashes corresponding to the block numbers
+    l2_block_hashes: Vec<B256>,
     /// The L1 network of the request
     l1_network: String,
     /// The L2 network of the request
@@ -432,12 +434,14 @@ pub struct RealTimeInputRequestKey {
 impl RealTimeInputRequestKey {
     pub fn new(
         l2_block_numbers: Vec<u64>,
+        l2_block_hashes: Vec<B256>,
         l1_network: String,
         l2_network: String,
         last_finalized_block_hash: B256,
     ) -> Self {
         Self {
             l2_block_numbers,
+            l2_block_hashes,
             l1_network,
             l2_network,
             last_finalized_block_hash,


### PR DESCRIPTION
## Summary
- Polling requests (empty `sources`) for the `/batch/realtime` endpoint now short-circuit to a status-only check instead of being submitted to the proving queue, preventing panics from empty `data_sources`
- Changed `use_cache` default from `false` to `true` for RealTime requests so proofs are cached by default; `use_cache: false` evicts before re-proving
- Added `l2_block_hashes` field to the request and cache key so reorgs at the same block number don't serve stale proofs
- Fixed memory backend to respect TTL expiry (was previously ignored with `_ttl`), so proofs expire consistently whether using Redis or in-memory storage

## Context
The caller uses a two-phase pattern:
1. **Submit**: POST with full `sources` + `blobs` → kicks off proving
2. **Poll**: POST with empty `sources` + `blobs` → check status

When `use_cache` defaulted to `false`, the proof was immediately evicted from the pool after success. The next poll (empty sources) would then be treated as a new prove request, causing a panic at `lib/src/utils/txs.rs:109` (`data_source is empty`).

## Test plan
- [ ] Verify realtime proving flow: first request with sources starts proving, polling with empty sources returns status
- [ ] Verify proof persists in Redis/memory until TTL expiry
- [ ] Verify `use_cache: false` evicts and re-proves correctly
- [ ] Verify `l2_block_hashes` must match between submit and poll for cache hit