### PR TITLE
feat: realtime blob privacy with hash-bound guest decryption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9482,6 +9482,7 @@ dependencies = [
 name = "raiko-lib"
 version = "0.1.0"
 dependencies = [
+ "aes-gcm",
  "alethia-reth-block",
  "alethia-reth-chainspec",
  "alethia-reth-consensus",
@@ -9505,6 +9506,7 @@ dependencies = [
  "flate2",
  "hex",
  "hex-literal",
+ "hkdf",
  "k256 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "kzg",
  "lazy_static",

--- a/core/src/preflight/util.rs
+++ b/core/src/preflight/util.rs
@@ -374,6 +374,8 @@ async fn prepare_pacaya_batch_input(
             blob_proof_type: blob_proof_type.clone(),
             is_forced_inclusion: is_forced_inclusion,
         }],
+        privacy_symmetric_key: None,
+        privacy_fi_private_key: None,
     })
 }
 
@@ -449,6 +451,8 @@ async fn prepare_shasta_batch_input(
         prover_data: prover_data,
         l2_grandparent_header: grandparent_header,
         data_sources,
+        privacy_symmetric_key: None,
+        privacy_fi_private_key: None,
     })
 }
 
@@ -595,6 +599,7 @@ async fn prepare_taiko_chain_batch_input_realtime(
     for derivation_source in realtime_event_data.proposal.sources.clone() {
         let blob_hashes = derivation_source.blobSlice.blobHashes;
         let l1_blob_timestamp: u64 = derivation_source.blobSlice.timestamp.to();
+        let is_forced_inclusion = derivation_source.isForcedInclusion;
 
         let (tx_data_from_calldata, blob_tx_buffers_with_proofs) = if blob_hashes.is_empty() {
             unimplemented!("calldata txlist is not supported in realtime");
@@ -662,11 +667,19 @@ async fn prepare_taiko_chain_batch_input_realtime(
                 .map(|(_, _, proof)| proof.clone())
                 .collect(),
             blob_proof_type: blob_proof_type.clone(),
-            is_forced_inclusion: false, // RealTime: forced inclusions removed
+            is_forced_inclusion,
         });
     }
 
     // 5. Return TaikoGuestBatchInput
+    //
+    // Privacy keys are read from operator env vars at preflight time. The guest verifies
+    // these against compile-time keccak256 hashes (`SURGE_PRIVACY_*_KEY_HASH`) baked into
+    // its binary, so a runtime mismatch produces an unverifiable proof rather than silent
+    // wrong-key decryption.
+    let privacy_symmetric_key = parse_hex_32_env("SURGE_PRIVACY_SYMMETRIC_KEY");
+    let privacy_fi_private_key = parse_hex_32_env("SURGE_PRIVACY_FI_PRIVKEY");
+
     Ok(TaikoGuestBatchInput {
         batch_id: 0, // RealTime has no on-chain proposal ID
         batch_proposed: BlockProposedFork::RealTime(realtime_event_data),
@@ -679,7 +692,31 @@ async fn prepare_taiko_chain_batch_input_realtime(
         prover_data,
         l2_grandparent_header: grandparent_header,
         data_sources,
+        privacy_symmetric_key,
+        privacy_fi_private_key,
     })
+}
+
+/// Reads a hex-encoded (with or without `0x` prefix) 32-byte value from the named env
+/// var. Returns `None` if the env var is unset; logs a warning if it is set but malformed.
+fn parse_hex_32_env(name: &str) -> Option<[u8; 32]> {
+    let raw = std::env::var(name).ok()?;
+    let s = raw.strip_prefix("0x").unwrap_or(&raw);
+    match hex::decode(s) {
+        Ok(bytes) if bytes.len() == 32 => {
+            let mut arr = [0u8; 32];
+            arr.copy_from_slice(&bytes);
+            Some(arr)
+        }
+        Ok(bytes) => {
+            tracing::warn!("{name}: expected 32 bytes, got {}", bytes.len());
+            None
+        }
+        Err(e) => {
+            tracing::warn!("{name}: invalid hex: {e}");
+            None
+        }
+    }
 }
 
 /// Prepare the input for a Taiko chain

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -109,6 +109,23 @@ pub struct Opts {
         help = "e.g. {\"Sp1\":0.1,\"Risc0\":0.2}"
     )]
     pub ballot_zk: String,
+
+    /// Realtime blob privacy mode. When true, encrypted blob payloads are decrypted
+    /// in the guest using the keys below. Must match the proposer's `SURGE_PRIVACY_MODE`.
+    #[arg(long, require_equals = true, env = "SURGE_PRIVACY_MODE")]
+    #[serde(default)]
+    pub privacy_mode: bool,
+
+    /// Hex-encoded 32-byte AES-256-GCM key for scheme 0x01 (normal proposal blobs).
+    /// Required when `privacy_mode` is true.
+    #[arg(long, require_equals = true, env = "SURGE_PRIVACY_SYMMETRIC_KEY")]
+    pub privacy_symmetric_key: Option<String>,
+
+    /// Hex-encoded 32-byte secp256k1 system FI private key for scheme 0x02 (forced
+    /// inclusion blobs). Required when `privacy_mode` is true *and* the chain accepts
+    /// forced inclusions.
+    #[arg(long, require_equals = true, env = "SURGE_PRIVACY_FI_PRIVKEY")]
+    pub privacy_fi_private_key: Option<String>,
 }
 
 impl Opts {

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -27,8 +27,12 @@ alloy-consensus = { workspace = true, features = ["crypto-backend"] }
 alloy-chains = { workspace = true }
 
 # Crypto deps (re-exported for guest crate)
-k256 = { version = "0.13", default-features = false, features = ["ecdsa"] }
+k256 = { version = "0.13", default-features = false, features = ["ecdsa", "ecdh"] }
 tiny-keccak = { version = "2.0", features = ["keccak"] }
+
+# Privacy / blob encryption (no_std-compatible RustCrypto crates).
+aes-gcm = { version = "0.10", default-features = false, features = ["aes", "alloc"] }
+hkdf = { version = "0.12", default-features = false }
 
 # errors
 anyhow = { workspace = true }

--- a/lib/src/input.rs
+++ b/lib/src/input.rs
@@ -103,6 +103,14 @@ pub struct TaikoGuestBatchInput {
     /// L2 grandparent header for the first block in the batch (used for EIP-4396 base fee calculation)
     #[serde_as(as = "Option<BincodeCompactHeader>")]
     pub l2_grandparent_header: Option<Header>,
+    /// Realtime blob privacy keys forwarded to the guest. The guest verifies that the
+    /// keccak256 of each provided key matches a compile-time hash baked into the guest
+    /// (`SURGE_PRIVACY_*_KEY_HASH`) — this binds the proof's vkey to the keys without
+    /// committing the secrets in the public input.
+    #[serde(default)]
+    pub privacy_symmetric_key: Option<[u8; 32]>,
+    #[serde(default)]
+    pub privacy_fi_private_key: Option<[u8; 32]>,
 }
 
 /// External block input.

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -33,6 +33,7 @@ pub mod libhash;
 pub mod manifest;
 pub mod mem_db;
 pub mod primitives;
+pub mod privacy;
 pub mod proof_type;
 pub mod protocol_instance;
 pub mod prover;

--- a/lib/src/privacy/aes.rs
+++ b/lib/src/privacy/aes.rs
@@ -1,0 +1,128 @@
+//! AES-256-GCM cipher (scheme 0x01).
+//!
+//! Blob layout (the bytes after the leading 0x01 scheme byte that the dispatcher strips):
+//!
+//! ```text
+//! [ nonce (12B) ] [ ciphertext (len(M) bytes) ] [ tag (16B) ]
+//! ```
+//!
+//! `M` is the compressed manifest, identical to what would have been the inner blob
+//! payload in non-privacy mode. AES-GCM is a stream-cipher mode so `len(ciphertext) == len(M)`.
+
+extern crate alloc;
+
+use aes_gcm::aead::{Aead, KeyInit, Payload};
+use aes_gcm::{Aes256Gcm, Key, Nonce};
+use alloc::vec::Vec;
+
+use super::CipherError;
+
+/// Length of the AES-256 key in bytes.
+pub const KEY_LEN: usize = 32;
+/// Length of the AES-GCM nonce in bytes (96-bit).
+pub const NONCE_LEN: usize = 12;
+/// Length of the AES-GCM authentication tag in bytes.
+pub const TAG_LEN: usize = 16;
+/// Minimum length of a scheme-0x01 inner payload (just the header fields, no plaintext).
+pub const MIN_INNER_LEN: usize = NONCE_LEN + TAG_LEN;
+
+/// Encrypts `plaintext` with AES-256-GCM under `key` and `nonce`, returning the
+/// scheme-0x01 *inner* payload `[nonce || ciphertext || tag]` (without the leading
+/// scheme byte — callers prepend it).
+///
+/// `nonce` MUST come from a CSPRNG and never be reused with the same key.
+pub fn encrypt(
+    plaintext: &[u8],
+    key: &[u8; KEY_LEN],
+    nonce: &[u8; NONCE_LEN],
+) -> Result<Vec<u8>, CipherError> {
+    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(key));
+    let ct = cipher
+        .encrypt(
+            Nonce::from_slice(nonce),
+            Payload {
+                msg: plaintext,
+                aad: &[],
+            },
+        )
+        .map_err(|_| CipherError::AeadFailed)?;
+
+    let mut out = Vec::with_capacity(NONCE_LEN + ct.len());
+    out.extend_from_slice(nonce);
+    out.extend_from_slice(&ct);
+    Ok(out)
+}
+
+/// Decrypts a scheme-0x01 inner payload `[nonce || ciphertext || tag]`.
+///
+/// The returned bytes are the plaintext compressed manifest `M`, unchanged in length
+/// from the encryption call's input.
+pub fn decrypt(inner: &[u8], key: &[u8; KEY_LEN]) -> Result<Vec<u8>, CipherError> {
+    if inner.len() < MIN_INNER_LEN {
+        return Err(CipherError::Truncated);
+    }
+    let (nonce, ct_and_tag) = inner.split_at(NONCE_LEN);
+    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(key));
+    cipher
+        .decrypt(
+            Nonce::from_slice(nonce),
+            Payload {
+                msg: ct_and_tag,
+                aad: &[],
+            },
+        )
+        .map_err(|_| CipherError::AeadFailed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const KEY: [u8; 32] = [0x42u8; 32];
+    const NONCE: [u8; 12] = [0x37u8; 12];
+
+    #[test]
+    fn roundtrip() {
+        let m = b"hello realtime privacy";
+        let inner = encrypt(m, &KEY, &NONCE).unwrap();
+
+        // Layout: nonce (12) + ct (len(m)) + tag (16)
+        assert_eq!(inner.len(), 12 + m.len() + 16);
+        assert_eq!(&inner[..12], &NONCE);
+
+        let pt = decrypt(&inner, &KEY).unwrap();
+        assert_eq!(pt, m);
+    }
+
+    #[test]
+    fn empty_plaintext_roundtrip() {
+        let m: &[u8] = b"";
+        let inner = encrypt(m, &KEY, &NONCE).unwrap();
+        assert_eq!(inner.len(), 12 + 16);
+
+        let pt = decrypt(&inner, &KEY).unwrap();
+        assert_eq!(pt, m);
+    }
+
+    #[test]
+    fn tampered_ciphertext_fails() {
+        let inner = encrypt(b"abcdef", &KEY, &NONCE).unwrap();
+        let mut bad = inner.clone();
+        // Flip one byte of the ciphertext (after the 12-byte nonce, before the tag).
+        bad[14] ^= 0x01;
+        assert_eq!(decrypt(&bad, &KEY).unwrap_err(), CipherError::AeadFailed);
+    }
+
+    #[test]
+    fn wrong_key_fails() {
+        let inner = encrypt(b"abc", &KEY, &NONCE).unwrap();
+        let other = [0x99u8; 32];
+        assert_eq!(decrypt(&inner, &other).unwrap_err(), CipherError::AeadFailed);
+    }
+
+    #[test]
+    fn truncated_inner_fails() {
+        let inner = [0u8; MIN_INNER_LEN - 1];
+        assert_eq!(decrypt(&inner, &KEY).unwrap_err(), CipherError::Truncated);
+    }
+}

--- a/lib/src/privacy/ecies.rs
+++ b/lib/src/privacy/ecies.rs
@@ -1,0 +1,211 @@
+//! ECIES cipher (scheme 0x02): secp256k1 ECDH ⊕ HKDF-SHA256 ⊕ AES-256-GCM.
+//!
+//! Used for forced-inclusion blobs in privacy mode. The submitter encrypts the
+//! compressed manifest `M` to the system's static public key `PK_sys`; only holders
+//! of the corresponding private key `SK_sys` can decrypt.
+//!
+//! Blob layout (after the leading 0x02 scheme byte the dispatcher strips):
+//!
+//! ```text
+//! [ pk_eph (33B compressed secp256k1) ] [ ciphertext (len(M)) ] [ tag (16B) ]
+//! ```
+//!
+//! The AES-GCM nonce is NOT carried on the wire — both sides derive it from the
+//! ECDH shared secret via HKDF-SHA256, alongside the AES key. See `super::ECIES_INFO`.
+//!
+//! Submitter side:
+//! 1. Draw ephemeral `(sk_eph, pk_eph)` on secp256k1 from a CSPRNG.
+//! 2. `s = ECDH(sk_eph, PK_sys)`.
+//! 3. `(K_eph || nonce_eph) = HKDF-SHA256(salt=∅, ikm=s, info="surge-fi-v1", L=44)`.
+//! 4. `C || tag = AES-256-GCM(K_eph, nonce_eph, M, aad=∅)`.
+//! 5. Emit `[pk_eph || C || tag]`; discard `sk_eph`.
+//!
+//! System side reverses with `s = ECDH(SK_sys, pk_eph)`.
+
+extern crate alloc;
+
+use aes_gcm::aead::{Aead, KeyInit, Payload};
+use aes_gcm::{Aes256Gcm, Key, Nonce};
+use alloc::vec::Vec;
+use hkdf::Hkdf;
+use k256::ecdh::diffie_hellman;
+use k256::elliptic_curve::sec1::ToEncodedPoint;
+use k256::{NonZeroScalar, PublicKey, SecretKey};
+use sha2::Sha256;
+
+use super::{CipherError, ECIES_INFO};
+
+/// Length of a compressed secp256k1 pubkey in bytes (header + 32-byte x-coord).
+pub const PK_LEN: usize = 33;
+/// Length of an AES-256 key in bytes.
+pub const KEY_LEN: usize = 32;
+/// Length of the AES-GCM nonce in bytes.
+pub const NONCE_LEN: usize = 12;
+/// Length of the AES-GCM authentication tag in bytes.
+pub const TAG_LEN: usize = 16;
+/// HKDF output length (key + nonce concatenated).
+const HKDF_LEN: usize = KEY_LEN + NONCE_LEN;
+/// Minimum length of a scheme-0x02 inner payload.
+pub const MIN_INNER_LEN: usize = PK_LEN + TAG_LEN;
+
+/// Encrypts `plaintext` to the system pubkey `system_pk` using the supplied ephemeral
+/// private key `sk_eph`. Returns the scheme-0x02 *inner* payload `[pk_eph || ct || tag]`
+/// (without the leading scheme byte).
+///
+/// In production, callers MUST generate `sk_eph` from a CSPRNG and never reuse it.
+/// This function is exposed primarily for tests; off-system FI submitters typically
+/// use a separate CLI / library to perform the encrypt step before broadcasting their
+/// blob tx.
+pub fn encrypt(
+    plaintext: &[u8],
+    system_pk: &[u8; PK_LEN],
+    sk_eph: &[u8; 32],
+) -> Result<Vec<u8>, CipherError> {
+    let recipient = PublicKey::from_sec1_bytes(system_pk).map_err(|_| CipherError::InvalidKey)?;
+    let secret = SecretKey::from_slice(&sk_eph[..]).map_err(|_| CipherError::InvalidKey)?;
+    let scalar = NonZeroScalar::from(&secret);
+
+    // pk_eph = sk_eph * G (compressed for the wire)
+    let pk_eph = secret.public_key();
+    let pk_eph_bytes = pk_eph.to_encoded_point(true);
+    debug_assert_eq!(pk_eph_bytes.as_bytes().len(), PK_LEN);
+
+    // ECDH: s = sk_eph * PK_sys
+    let shared = diffie_hellman(scalar, recipient.as_affine());
+    let ikm = shared.raw_secret_bytes();
+
+    let (k_eph, nonce_eph) = derive_key_and_nonce(ikm.as_slice())?;
+
+    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(&k_eph));
+    let ct = cipher
+        .encrypt(
+            Nonce::from_slice(&nonce_eph),
+            Payload {
+                msg: plaintext,
+                aad: &[],
+            },
+        )
+        .map_err(|_| CipherError::AeadFailed)?;
+
+    let mut out = Vec::with_capacity(PK_LEN + ct.len());
+    out.extend_from_slice(pk_eph_bytes.as_bytes());
+    out.extend_from_slice(&ct);
+    Ok(out)
+}
+
+/// Decrypts a scheme-0x02 inner payload `[pk_eph || ct || tag]` using the system
+/// private key `sk_sys`. Returns the plaintext compressed manifest.
+pub fn decrypt(inner: &[u8], sk_sys: &[u8; 32]) -> Result<Vec<u8>, CipherError> {
+    if inner.len() < MIN_INNER_LEN {
+        return Err(CipherError::Truncated);
+    }
+    let (pk_eph_bytes, ct_and_tag) = inner.split_at(PK_LEN);
+
+    let pk_eph = PublicKey::from_sec1_bytes(pk_eph_bytes)
+        .map_err(|_| CipherError::InvalidEphemeralPubkey)?;
+    let secret = SecretKey::from_slice(&sk_sys[..]).map_err(|_| CipherError::InvalidKey)?;
+    let scalar = NonZeroScalar::from(&secret);
+
+    let shared = diffie_hellman(scalar, pk_eph.as_affine());
+    let ikm = shared.raw_secret_bytes();
+
+    let (k_eph, nonce_eph) = derive_key_and_nonce(ikm.as_slice())?;
+
+    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(&k_eph));
+    cipher
+        .decrypt(
+            Nonce::from_slice(&nonce_eph),
+            Payload {
+                msg: ct_and_tag,
+                aad: &[],
+            },
+        )
+        .map_err(|_| CipherError::AeadFailed)
+}
+
+/// HKDF-SHA256(salt=∅, ikm=shared_secret, info=`super::ECIES_INFO`, L=44 bytes).
+/// First 32 bytes are the AES-256 key; next 12 bytes are the AES-GCM nonce.
+fn derive_key_and_nonce(ikm: &[u8]) -> Result<([u8; KEY_LEN], [u8; NONCE_LEN]), CipherError> {
+    let mut out = [0u8; HKDF_LEN];
+    let hk = Hkdf::<Sha256>::new(None, ikm);
+    hk.expand(ECIES_INFO, &mut out)
+        .map_err(|_| CipherError::AeadFailed)?;
+
+    let mut key = [0u8; KEY_LEN];
+    let mut nonce = [0u8; NONCE_LEN];
+    key.copy_from_slice(&out[..KEY_LEN]);
+    nonce.copy_from_slice(&out[KEY_LEN..]);
+    Ok((key, nonce))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use k256::elliptic_curve::sec1::ToEncodedPoint;
+    use k256::SecretKey;
+
+    fn make_keypair(seed: u8) -> ([u8; 32], [u8; PK_LEN]) {
+        let sk_bytes = [seed; 32];
+        let sk = SecretKey::from_slice(&sk_bytes).unwrap();
+        let pk = sk.public_key();
+        let pk_bytes = pk.to_encoded_point(true);
+        let mut pk_arr = [0u8; PK_LEN];
+        pk_arr.copy_from_slice(pk_bytes.as_bytes());
+        (sk_bytes, pk_arr)
+    }
+
+    #[test]
+    fn roundtrip() {
+        let (sk_sys, pk_sys) = make_keypair(0x11);
+        let (sk_eph, _pk_eph) = make_keypair(0x22);
+
+        let m = b"forced inclusion plaintext payload";
+        let inner = encrypt(m, &pk_sys, &sk_eph).unwrap();
+
+        // First 33 bytes are pk_eph, the rest is ct + tag.
+        assert!(inner.len() >= PK_LEN + TAG_LEN);
+        assert_eq!(inner.len(), PK_LEN + m.len() + TAG_LEN);
+
+        let pt = decrypt(&inner, &sk_sys).unwrap();
+        assert_eq!(pt, m);
+    }
+
+    #[test]
+    fn wrong_recipient_fails() {
+        let (_sk_sys, pk_sys) = make_keypair(0x11);
+        let (sk_eph, _) = make_keypair(0x22);
+
+        let inner = encrypt(b"x", &pk_sys, &sk_eph).unwrap();
+
+        let (sk_other, _) = make_keypair(0x33);
+        assert_eq!(decrypt(&inner, &sk_other).unwrap_err(), CipherError::AeadFailed);
+    }
+
+    #[test]
+    fn tampered_ct_fails() {
+        let (sk_sys, pk_sys) = make_keypair(0x11);
+        let (sk_eph, _) = make_keypair(0x22);
+
+        let mut inner = encrypt(b"abcdef", &pk_sys, &sk_eph).unwrap();
+        // Flip a byte in the ciphertext (after the 33-byte pk_eph).
+        inner[PK_LEN + 1] ^= 0x01;
+        assert_eq!(decrypt(&inner, &sk_sys).unwrap_err(), CipherError::AeadFailed);
+    }
+
+    #[test]
+    fn truncated_inner_fails() {
+        let inner = [0u8; MIN_INNER_LEN - 1];
+        let sk = [0x11u8; 32];
+        assert_eq!(decrypt(&inner, &sk).unwrap_err(), CipherError::Truncated);
+    }
+
+    #[test]
+    fn invalid_pk_eph_fails() {
+        let mut inner = [0u8; PK_LEN + TAG_LEN + 1];
+        // Make the first byte an invalid SEC1 prefix and zero the rest.
+        inner[0] = 0xFF;
+        let sk = [0x11u8; 32];
+        let err = decrypt(&inner, &sk).unwrap_err();
+        assert_eq!(err, CipherError::InvalidEphemeralPubkey);
+    }
+}

--- a/lib/src/privacy/mod.rs
+++ b/lib/src/privacy/mod.rs
@@ -1,0 +1,141 @@
+//! Blob privacy: pluggable encryption schemes for realtime proposal blobs.
+//!
+//! Each privacy blob payload (the inner buffer carried by an EIP-4844 sidecar after
+//! the existing `[version (1B)][size (3B BE)]` framing) starts with a 1-byte scheme id
+//! that selects the cipher used. See `surge-taiko-mono/PRIVACY_STACK.md` for the full
+//! byte-layout specification.
+//!
+//! Schemes:
+//! - `0x00` = plaintext: payload is the compressed manifest verbatim.
+//! - `0x01` = AES-256-GCM: a single shared symmetric key encrypts every Catalyst-built
+//!   proposal blob with a fresh CSPRNG nonce embedded in the header.
+//! - `0x02` = ECIES (secp256k1 + AES-GCM): a fresh ephemeral keypair per submission;
+//!   shared secret derived via ECDH against the system's static public key, expanded
+//!   to (key, nonce) via HKDF-SHA256.
+//!
+//! This module is `no_std`-compatible (alloc only) so it can run inside the SP1, Risc0,
+//! and Zisk guest binaries.
+
+#![allow(clippy::module_name_repetitions)]
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+
+pub mod aes;
+pub mod ecies;
+
+/// Plaintext (no encryption); payload is the compressed manifest verbatim.
+pub const SCHEME_PLAIN: u8 = 0x00;
+/// AES-256-GCM with a shared symmetric key.
+pub const SCHEME_AES256_GCM: u8 = 0x01;
+/// ECIES = secp256k1 ECDH ⊕ HKDF-SHA256 ⊕ AES-256-GCM.
+pub const SCHEME_ECIES_SECP256K1: u8 = 0x02;
+
+/// Errors returned by encryption/decryption helpers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CipherError {
+    /// The blob's leading scheme byte is not recognized.
+    UnknownScheme(u8),
+    /// The blob is shorter than the minimum length required by its scheme header.
+    Truncated,
+    /// The decryption key for the blob's scheme is not configured.
+    KeyMissing,
+    /// The provided key bytes have the wrong length or invalid format.
+    InvalidKey,
+    /// AEAD authentication failed (bad key, nonce, or ciphertext tampering).
+    AeadFailed,
+    /// ECIES ephemeral pubkey could not be parsed.
+    InvalidEphemeralPubkey,
+}
+
+/// Keys passed to `dispatch_decrypt`. Only the key required by the blob's actual scheme
+/// must be `Some`; the others may be `None`.
+#[derive(Default, Clone)]
+pub struct DecryptKeys {
+    /// Shared 32-byte AES-256-GCM key used by Catalyst's normal proposals (scheme 0x01).
+    pub symmetric: Option<[u8; 32]>,
+    /// 32-byte secp256k1 scalar (system FI private key, scheme 0x02).
+    pub fi_private: Option<[u8; 32]>,
+}
+
+/// Decrypt a privacy blob payload (the bytes following the outer `[version][size]` frame).
+///
+/// Reads the leading scheme byte and dispatches to the right cipher. For scheme `0x00`
+/// the remaining bytes are returned verbatim.
+pub fn dispatch_decrypt(blob: &[u8], keys: &DecryptKeys) -> Result<Vec<u8>, CipherError> {
+    let (scheme, rest) = blob.split_first().ok_or(CipherError::Truncated)?;
+    match *scheme {
+        SCHEME_PLAIN => Ok(rest.to_vec()),
+        SCHEME_AES256_GCM => {
+            let key = keys.symmetric.ok_or(CipherError::KeyMissing)?;
+            aes::decrypt(rest, &key)
+        }
+        SCHEME_ECIES_SECP256K1 => {
+            let sk = keys.fi_private.ok_or(CipherError::KeyMissing)?;
+            ecies::decrypt(rest, &sk)
+        }
+        other => Err(CipherError::UnknownScheme(other)),
+    }
+}
+
+/// HKDF-SHA256 info string for ECIES key/nonce derivation (scheme 0x02).
+///
+/// Both submitter and system MUST use this exact byte string to derive matching
+/// `(K_eph, nonce_eph)` from the ECDH shared secret.
+pub const ECIES_INFO: &[u8] = b"surge-fi-v1";
+
+/// Computes keccak256 of the input. Used in the guest to bind the witness-supplied
+/// privacy keys to compile-time hashes baked via `build.rs` — this means the proof's
+/// vkey commits to the keys without committing the secret bytes in the public input.
+pub fn keccak256_32(input: &[u8]) -> [u8; 32] {
+    use tiny_keccak::{Hasher, Keccak};
+    let mut hasher = Keccak::v256();
+    hasher.update(input);
+    let mut out = [0u8; 32];
+    hasher.finalize(&mut out);
+    out
+}
+
+/// Asserts that `keccak256(key) == expected_hash`. Returns `Err(InvalidKey)` on mismatch.
+/// Use in guest code to verify a witness-supplied key matches the compile-time hash.
+pub fn assert_key_hash(key: &[u8; 32], expected_hash: &[u8; 32]) -> Result<(), CipherError> {
+    if &keccak256_32(key) == expected_hash {
+        Ok(())
+    } else {
+        Err(CipherError::InvalidKey)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dispatch_plaintext() {
+        let payload = [0x00u8, b'h', b'i'];
+        let out = dispatch_decrypt(&payload, &DecryptKeys::default()).unwrap();
+        assert_eq!(out, b"hi");
+    }
+
+    #[test]
+    fn dispatch_unknown_scheme() {
+        let payload = [0xFFu8, 0xAA];
+        let err = dispatch_decrypt(&payload, &DecryptKeys::default()).unwrap_err();
+        assert_eq!(err, CipherError::UnknownScheme(0xFF));
+    }
+
+    #[test]
+    fn dispatch_aes_missing_key() {
+        let payload = [SCHEME_AES256_GCM, 0u8];
+        let err = dispatch_decrypt(&payload, &DecryptKeys::default()).unwrap_err();
+        assert_eq!(err, CipherError::KeyMissing);
+    }
+
+    #[test]
+    fn dispatch_truncated_blob() {
+        let payload: [u8; 0] = [];
+        let err = dispatch_decrypt(&payload, &DecryptKeys::default()).unwrap_err();
+        assert_eq!(err, CipherError::Truncated);
+    }
+}

--- a/lib/src/utils/realtime.rs
+++ b/lib/src/utils/realtime.rs
@@ -9,7 +9,23 @@ use crate::input::GuestBatchInput;
 use crate::manifest::DerivationSourceManifest;
 #[cfg(not(feature = "std"))]
 use crate::no_std::*;
+use crate::privacy::{self, DecryptKeys};
 use crate::utils::blobs::{decode_blob_data, zlib_decompress_data};
+
+/// Parses a hex-encoded 32-byte value (with or without `0x` prefix) at compile time
+/// or runtime. Returns `None` on malformed input.
+fn parse_hex_32(s: &str) -> Option<[u8; 32]> {
+    let s = s.strip_prefix("0x").unwrap_or(s);
+    if s.len() != 64 {
+        return None;
+    }
+    let mut out = [0u8; 32];
+    for i in 0..32 {
+        let byte = u8::from_str_radix(&s[i * 2..i * 2 + 2], 16).ok()?;
+        out[i] = byte;
+    }
+    Some(out)
+}
 use crate::utils::shasta_rules::{
     clamp_timestamp_lower_bound, validate_force_inc_proposal_manifest, validate_input_block_param,
     validate_realtime_proposal_manifest, validate_shasta_block_base_fee,
@@ -81,6 +97,38 @@ pub fn generate_transactions_for_realtime_blocks(
     let mut last_parent_block_timestamp = last_parent_block_header.timestamp;
     let mut last_parent_block_gas_limit = last_parent_block_header.gas_limit;
 
+    // Privacy keys forwarded by the host. Identical for every source within a batch.
+    //
+    // Bind the witness keys to compile-time hashes baked into the guest. The hash
+    // hex is provided via `SURGE_PRIVACY_*_KEY_HASH` build-time env vars; when
+    // unset we fall back to `0x00..00` and bypass the check (non-privacy builds).
+    // The hash check is what makes the proof's vkey commit to the keys without
+    // leaking the secret bytes through the public input.
+    if let Some(ref key) = taiko_guest_batch_input.privacy_symmetric_key {
+        if let Some(hash_hex) = option_env!("SURGE_PRIVACY_SYMMETRIC_KEY_HASH") {
+            if let Some(expected) = parse_hex_32(hash_hex) {
+                if expected != [0u8; 32] {
+                    privacy::assert_key_hash(key, &expected)
+                        .expect("privacy symmetric key hash mismatch — guest vkey rejects this key");
+                }
+            }
+        }
+    }
+    if let Some(ref key) = taiko_guest_batch_input.privacy_fi_private_key {
+        if let Some(hash_hex) = option_env!("SURGE_PRIVACY_FI_PRIVKEY_HASH") {
+            if let Some(expected) = parse_hex_32(hash_hex) {
+                if expected != [0u8; 32] {
+                    privacy::assert_key_hash(key, &expected)
+                        .expect("privacy FI private key hash mismatch — guest vkey rejects this key");
+                }
+            }
+        }
+    }
+    let privacy_keys = DecryptKeys {
+        symmetric: taiko_guest_batch_input.privacy_symmetric_key,
+        fi_private: taiko_guest_batch_input.privacy_fi_private_key,
+    };
+
     for (idx, data_source) in data_sources.iter().enumerate() {
         let use_blob = batch_proposal.blob_used();
         let compressed_tx_list_buf = if use_blob {
@@ -99,7 +147,23 @@ pub fn generate_transactions_for_realtime_blocks(
                         .map(|s| s.to_vec())
                 })
                 .unwrap_or_default();
-            sliced
+
+            // Privacy: dispatch on the leading scheme byte. For scheme 0x00 this is a
+            // pass-through (returns the bytes after the prefix). For 0x01 / 0x02 this
+            // decrypts using the witness-supplied keys. On failure for non-FI sources
+            // the caller will fall through to the default-manifest fallback below
+            // (matching the driver's behavior); for FI sources the same fallback path
+            // already handles arbitrary garbage payloads.
+            match privacy::dispatch_decrypt(&sliced, &privacy_keys) {
+                Ok(plaintext) => plaintext,
+                Err(e) => {
+                    warn!(
+                        "privacy dispatch failed for source idx={}, is_forced_inclusion={}: {:?}",
+                        idx, data_source.is_forced_inclusion, e
+                    );
+                    Vec::new()
+                }
+            }
         } else {
             unreachable!("realtime does not use calldata");
         };


### PR DESCRIPTION
## Summary

Adds the prover side of the cross-stack privacy feature for the Surge realtime fork. Encrypted blob payloads on L1 are decrypted **inside the ZK guest**, with witness-supplied keys verified against `keccak256` hashes baked into the guest binary at compile time. The deployed vkey thus commits to the keys without ever leaking the secret bytes in the public input.

- **`lib/src/privacy/`** — new `no_std`-compatible cipher module shared between host and guest. AES-256-GCM (scheme 0x01) for normal proposals, ECIES on secp256k1 (scheme 0x02) for forced inclusion. Uses RustCrypto `aes-gcm` + `hkdf` + the existing `k256` crate (with the `ecdh` feature now enabled). Dispatcher reads the 1-byte scheme prefix and routes.
- **Witness** — `TaikoGuestBatchInput` carries optional `privacy_symmetric_key` and `privacy_fi_private_key` populated by the host's preflight from `SURGE_PRIVACY_*` env vars.
- **Hash binding (the security boundary)** — `lib/src/utils/realtime.rs` reads `SURGE_PRIVACY_*_KEY_HASH` at guest compile time via `option_env!` and asserts `keccak256(witness_key) == expected`. A non-zero hash mismatch panics the guest. When the env var is unset the check is bypassed (non-privacy builds).
- **Host CLI** — `--privacy-mode`, `--privacy-symmetric-key`, `--privacy-fi-private-key` on `Opts` (plus matching env vars).
- **Bug fix** — previous realtime preflight hardcoded `is_forced_inclusion: false` for every source, ignoring the on-chain flag. Now respects the `derivation_source.isForcedInclusion` value.

Companion PRs:
- [surge-taiko-mono#300](https://github.com/NethermindEth/surge-taiko-mono/pull/300) — protocol contracts + driver decryption
- [Catalyst#958](https://github.com/NethermindEth/Catalyst/pull/958) — proposer encryption + FI consumption

See [`PRIVACY_STACK.md`](https://github.com/NethermindEth/surge-taiko-mono/blob/feat/realtime-privacy/PRIVACY_STACK.md) for the cross-stack design reference (cipher registry, blob layouts, key management, FI lifecycle, PQ analysis, ops runbook).

## Test plan

- [ ] `cargo check -p raiko-lib -p raiko-core -p raiko-host` — builds clean.
- [ ] `cargo test -p raiko-lib privacy::` — 14 tests pass (4 dispatch + 5 AES + 5 ECIES).
- [ ] Build a guest (sp1 / risc0 / zisk) with `SURGE_PRIVACY_SYMMETRIC_KEY_HASH=0x...` set; record the resulting vkey and verify it changes when the hash changes.
- [ ] End-to-end with companion PRs: feed an encrypted blob from Catalyst, verify the guest decrypts and produces a valid proof; flip a witness-key bit and verify the guest panics.
- [ ] Verify migration: rotate the symmetric key, recompile the guest, redeploy `SurgeVerifier` with the new vkey, confirm the chain advances under the new keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)